### PR TITLE
Fix mysql plugin name master

### DIFF
--- a/docs/en/functions/10-access.mdx
+++ b/docs/en/functions/10-access.mdx
@@ -6,7 +6,7 @@ sourceSHA: be3a4ee0d358453b68a957db2dd805ce1f913ff56818f9dca4fde260003cfaf2
 # Access Methods
 
 ## Function Overview
-Alauda Database for MySQL-MGR provides multiple ways to access MySQL-MGR clusters, supporting both internal and external cluster access. This section describes how to obtain appropriate connection addresses and establish connections to MySQL-MGR instances using the `mysql` client tool both inside and outside the cluster.
+Alauda Database for MySQL provides multiple ways to access MySQL-MGR clusters, supporting both internal and external cluster access. This section describes how to obtain appropriate connection addresses and establish connections to MySQL-MGR instances using the `mysql` client tool both inside and outside the cluster.
 For detailed connection examples of client libraries, please refer to [How to Access MySQL-MGR Instances](../how_to/50-access)
 
 ## Procedure

--- a/docs/en/installation.mdx
+++ b/docs/en/installation.mdx
@@ -61,12 +61,12 @@ The plugin serves as a foundational component for Alauda Data Services web conso
   </Tab>
 </Tabs>
 
-## Installing Alauda Database for MySQL-MGR
+## Installing Alauda Database for MySQL
 
 ### Prerequisites
 
 1. Download the plugin installation package that matches the platform.
-2. Use the platform's application publishing capability to publish the plugin to any cluster where Alauda Database for MySQL-MGR capabilities are desired.
+2. Use the platform's application publishing capability to publish the plugin to any cluster where Alauda Database for MySQL capabilities are desired.
 
 ### Procedure
 

--- a/docs/en/intro.mdx
+++ b/docs/en/intro.mdx
@@ -7,7 +7,7 @@ i18n:
 title: Introduction
 ---
 
-Alauda Database for MySQL-MGR is a high availability database solution based on MySQL Group Replication technology and runs on Kubernetes. It provides automated deployment and management capabilities for MySQL Group Replication clusters.
+Alauda Database for MySQL is a high availability database solution based on MySQL Group Replication technology and runs on Kubernetes. It provides automated deployment and management capabilities for MySQL Group Replication clusters.
 
 ## Key Features
 

--- a/sites.yaml
+++ b/sites.yaml
@@ -1,3 +1,3 @@
 - name: acp
   base: /container_platform
-  version: "cherry-pick-08bd8da"
+  version: "fix-mysql-plugin-name-master"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product name from “Alauda Database for MySQL-MGR” to “Alauda Database for MySQL” across introduction, installation, and access/function overview pages.
  * Aligned prerequisites and installation wording with the new product naming; no changes to procedures or access methods.
* **Chores**
  * Updated site configuration version identifier to reflect the naming correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->