### PR TITLE
docs: add guide for deploying MySQL-MGR without TopoLVM

### DIFF
--- a/docs/en/how_to/40-deploy-without-topolvm.mdx
+++ b/docs/en/how_to/40-deploy-without-topolvm.mdx
@@ -285,12 +285,12 @@ To fix this, set the `hostPath` field in the `RdsInstaller` CR's `spec.slowSQLCK
             character_set_server: utf8mb4
             default_storage_engine: InnoDB
             default_time_zone: "+08:00"
-      passwordSecretName: mgr-${instance_name}-password
       version: "8.0"
     EOF
     ```
 
     :::info
+    - The password secret must follow the naming convention `mgr-${instance_name}-password`. The operator discovers it automatically by this name.
     - Set `storageClassName: mgr-local-pv` (or your StorageClass name) in the `volumeClaimTemplate` section. This replaces the default `sc-topolvm`.
     - The `version` field is required. Use `"8.0"` for MySQL 8.0.
     :::

--- a/docs/en/how_to/40-deploy-without-topolvm.mdx
+++ b/docs/en/how_to/40-deploy-without-topolvm.mdx
@@ -196,7 +196,7 @@ mkdir /cpaas: read-only file system
 ```
 
 :::warning
-You must configure the `hostPath` **before** installing the query-analytics-operator. Once installed, the operator immediately reconciles and creates the ClickHouse PV with the default `/cpaas/ck` path, which will fail on read-only filesystems.
+You must configure the `hostPath` **before** installing the query-analytics-operator. The `RdsInstaller → QueryAnalyticsInstaller` merge runs only when the `QueryAnalyticsInstaller` (`qai`) CR is first created. Once the operator is installed, the `qai` CR already exists and later edits to `RdsInstaller` will not propagate. To recover from an existing deployment, see [Fix an existing deployment](#fix-an-existing-deployment-with-the-wrong-hostpath).
 :::
 
 ### Configure hostPath before installing query-analytics-operator
@@ -231,18 +231,50 @@ You must configure the `hostPath` **before** installing the query-analytics-oper
 
 ### Fix an existing deployment with the wrong hostPath
 
-If the query-analytics-operator was already installed with the default path and ClickHouse pods are failing, update the `hostPath` as above, then delete the existing PV and recreate the ClickHouse pods:
+If the query-analytics-operator is already installed with the default path and ClickHouse pods are failing, editing only `RdsInstaller.spec.slowSQLCK.hostPath` is not enough — the merge into `QueryAnalyticsInstaller` only runs when `qai` is first created. You must also force `qai` to be recreated (or edit `qai` directly).
+
+**Option A — Recreate `qai` so the merge re-runs:**
+
+1. Update `RdsInstaller` as described in the pre-install procedure above:
+
+    ```bash
+    kubectl edit rdsinstaller <name> -n <namespace>
+    # set spec.slowSQLCK.hostPath: /opt/local-pv/ck
+    ```
+
+2. Delete the ClickHouse installation and the old PV:
+
+    ```bash
+    kubectl delete chi pxc-ck -n <clickhouse-namespace>
+    kubectl get pv | grep pxc-ck
+    kubectl delete pv <pv-name>
+    ```
+
+3. Delete the `QueryAnalyticsInstaller` CR. The query-analytics-operator will recreate it, merging the updated `RdsInstaller` settings:
+
+    ```bash
+    kubectl delete qai qai
+    ```
+
+4. Verify the new `hostPath`:
+
+    ```bash
+    kubectl get qai qai -o jsonpath='{.spec.slowSQL.hostPath}{"\n"}'
+    kubectl get pv pxc-ck-pv -o jsonpath='{.spec.hostPath.path}{"\n"}'
+    ```
+
+    Both should show the configured path (e.g. `/opt/local-pv/ck`).
+
+**Option B — Edit `qai` directly** (faster, but `RdsInstaller` will drift from `qai` until the next recreation):
 
 ```bash
-# Find and delete the old PV with the wrong hostPath
-kubectl get pv | grep ck
-kubectl delete pv <pv-name>
-
-# Find ClickHouse pods
-kubectl get pod -n <namespace> | grep clickhouse
-# Delete them to trigger recreation with the new path
-kubectl delete pod -n <namespace> <clickhouse-pod-names>
+kubectl edit qai qai
+# set spec.slowSQL.hostPath: /opt/local-pv/ck
+kubectl delete chi pxc-ck -n <clickhouse-namespace>
+kubectl delete pv <old-pv-name>
 ```
+
+The query-analytics-operator will recreate the ClickHouse installation and PV using the path set on `qai`.
 
 ## Step 4: Create a MySQL-MGR Instance
 

--- a/docs/en/how_to/40-deploy-without-topolvm.mdx
+++ b/docs/en/how_to/40-deploy-without-topolvm.mdx
@@ -177,41 +177,50 @@ All PVs should show `Available` status before proceeding.
 - Create more PVs than the minimum required to accommodate scaling and reprovisioning. However, extra PVs do not help with failover: if a node is lost, the PVs bound to it cannot be migrated. Recovery from node loss requires manual reprovisioning and data resync.
 :::
 
-## Step 3 (Optional): Fix ClickHouse Storage on Read-Only Filesystems
+## Step 3 (Optional): Configure ClickHouse Storage Path on Read-Only Filesystems
 
 :::info
 This step is only needed if you have the query-analytics plugin deployed and want slow query logging / query analysis features. If you do not use query analytics, skip this step — MySQL-MGR instances will function normally without it.
 :::
 
-The query-analytics plugin deploys ClickHouse using host directory PVs with a hardcoded path (`/cpaas/ck`). On MicroOS or other systems with a read-only root filesystem, this causes ClickHouse pods to fail with:
+The query-analytics plugin deploys ClickHouse using a host directory PV. By default, the host path is `/cpaas/ck`. On MicroOS or other systems with a read-only root filesystem, this causes ClickHouse pods to fail with:
 
 ```
 mkdir /cpaas: read-only file system
 ```
 
-To fix this, modify the query-analytics instance (`qai` resource) after the query-analytics plugin is deployed:
+To fix this, set the `hostPath` field in the `RdsInstaller` CR's `spec.slowSQLCK` section to a writable path before deploying the query-analytics plugin:
 
-1. Find the `qai` resource and inspect its current configuration:
-
-    ```bash
-    kubectl get qai -A
-    kubectl get qai <qai-name> -n <namespace> -o yaml | grep -A5 slowsql
-    ```
-
-2. Edit the `qai` resource and set the `storageClassName` field under `slowsql` to your StorageClass:
+1. Find the `RdsInstaller` resource:
 
     ```bash
-    kubectl edit qai <qai-name> -n <namespace>
+    kubectl get rdsinstaller -A
     ```
 
-    Change the `slowsql` section's `storageClassName` to `mgr-local-pv` (or your StorageClass name).
+2. Edit the `RdsInstaller` to override the ClickHouse host path:
 
-3. Find and recreate the ClickHouse pods to pick up the new storage configuration:
+    ```bash
+    kubectl edit rdsinstaller <name> -n <namespace>
+    ```
+
+    Set `spec.slowSQLCK.hostPath` to a writable path on the node:
+
+    ```yaml
+    spec:
+      slowSQLCK:
+        hostPath: /opt/local-pv/ck
+    ```
+
+    :::info
+    On MicroOS, use a path under `/opt/` (e.g., `/opt/local-pv/ck`). The directory will be created automatically with `DirectoryOrCreate` type.
+    :::
+
+3. If the query-analytics plugin was already deployed with the default path and ClickHouse pods are failing, update the `hostPath` as above, then recreate the ClickHouse pods:
 
     ```bash
     # Find ClickHouse pods
     kubectl get pod -n <namespace> | grep clickhouse
-    # Delete them to trigger recreation
+    # Delete them to trigger recreation with the new path
     kubectl delete pod -n <namespace> <clickhouse-pod-names>
     ```
 
@@ -373,6 +382,6 @@ kubectl annotate mysql ${instance_name} -n ${namespace} \
 
 **Symptom**: ClickHouse pods fail to start with `mkdir /cpaas: read-only file system`.
 
-**Cause**: The query-analytics plugin uses a hardcoded host path (`/cpaas/ck`) that does not exist on read-only filesystems.
+**Cause**: The query-analytics plugin's default ClickHouse host path (`/cpaas/ck`) does not exist on read-only filesystems.
 
-**Fix**: Follow [Step 3](#step-3-optional-fix-clickhouse-storage-on-read-only-filesystems) to update the `qai` resource with the correct StorageClass.
+**Fix**: Follow [Step 3](#step-3-optional-configure-clickhouse-storage-path-on-read-only-filesystems) to set `spec.slowSQLCK.hostPath` in the `RdsInstaller` CR to a writable path.

--- a/docs/en/how_to/40-deploy-without-topolvm.mdx
+++ b/docs/en/how_to/40-deploy-without-topolvm.mdx
@@ -132,9 +132,11 @@ NODE2=<node2-hostname>
 NODE3=<node3-hostname>
 
 # Create 3 PVs per node (9 total) to allow for scaling and reprovisioning
-for node in $NODE1 $NODE2 $NODE3; do
+nodes=("$NODE1" "$NODE2" "$NODE3")
+for n in "${!nodes[@]}"; do
+  node="${nodes[$n]}"
   for i in 1 2 3; do
-    idx=$(( ($(echo $NODE1 $NODE2 $NODE3 | tr ' ' '\n' | grep -n $node | cut -d: -f1) - 1) * 3 + i ))
+    idx=$(( n * 3 + i ))
     kubectl apply -f - <<EOF
 apiVersion: v1
 kind: PersistentVolume

--- a/docs/en/how_to/40-deploy-without-topolvm.mdx
+++ b/docs/en/how_to/40-deploy-without-topolvm.mdx
@@ -179,9 +179,7 @@ All PVs should show `Available` status before proceeding.
 - Create more PVs than the minimum required to accommodate scaling and reprovisioning. However, extra PVs do not help with failover: if a node is lost, the PVs bound to it cannot be migrated. Recovery from node loss requires manual reprovisioning and data resync.
 :::
 
-<a id="step-3-optional-configure-clickhouse-storage-path-on-read-only-filesystems"></a>
-
-## Step 3 (Optional): Configure ClickHouse Storage Path on Read-Only Filesystems
+## Step 3 (Optional): Configure ClickHouse Storage Path on Read-Only Filesystems \{#step-3-optional-configure-clickhouse-storage-path-on-read-only-filesystems}
 
 :::info
 This step is only needed if you have the query-analytics plugin deployed and want slow query logging / query analysis features. If you do not use query analytics, skip this step — MySQL-MGR instances will function normally without it.

--- a/docs/en/how_to/40-deploy-without-topolvm.mdx
+++ b/docs/en/how_to/40-deploy-without-topolvm.mdx
@@ -179,6 +179,8 @@ All PVs should show `Available` status before proceeding.
 - Create more PVs than the minimum required to accommodate scaling and reprovisioning. However, extra PVs do not help with failover: if a node is lost, the PVs bound to it cannot be migrated. Recovery from node loss requires manual reprovisioning and data resync.
 :::
 
+<a id="step-3-optional-configure-clickhouse-storage-path-on-read-only-filesystems"></a>
+
 ## Step 3 (Optional): Configure ClickHouse Storage Path on Read-Only Filesystems
 
 :::info

--- a/docs/en/how_to/40-deploy-without-topolvm.mdx
+++ b/docs/en/how_to/40-deploy-without-topolvm.mdx
@@ -183,7 +183,7 @@ All PVs should show `Available` status before proceeding.
 - Create more PVs than the minimum required to accommodate scaling and reprovisioning. However, extra PVs do not help with failover: if a node is lost, the PVs bound to it cannot be migrated. Recovery from node loss requires manual reprovisioning and data resync.
 :::
 
-## Step 3 (Optional): Configure ClickHouse Storage Path on Read-Only Filesystems \{#step-3-optional-configure-clickhouse-storage-path-on-read-only-filesystems}
+## Step 3 (Optional): Configure ClickHouse Storage Path on Read-Only Filesystems {/* #step-3-optional-configure-clickhouse-storage-path-on-read-only-filesystems */}
 
 :::info
 This step is only needed if you plan to use query analytics features (slow query logging, query analysis). If you do not use query analytics, skip this step — MySQL-MGR instances will function normally without it.

--- a/docs/en/how_to/40-deploy-without-topolvm.mdx
+++ b/docs/en/how_to/40-deploy-without-topolvm.mdx
@@ -52,6 +52,10 @@ If you need query analytics features (slow query logging, query analysis), the f
 | **clickhouse-operator** | ClickHouse database operator (used by query analytics) |
 | **query-analytics-operator** | Query analytics and slow query logging |
 
+:::warning
+On read-only filesystems (e.g., MicroOS), you **must** configure the ClickHouse storage path in the `RdsInstaller` CR **before** installing the query-analytics-operator. Otherwise, the operator will immediately create a ClickHouse PV at the default `/cpaas/ck` host path, which will fail with `read-only file system`. See [Step 3](#step-3-optional-configure-clickhouse-storage-path-on-read-only-filesystems) for details.
+:::
+
 :::info
 If your cluster uses TopoLVM, the `topolvm-operator` is also required. Since this guide covers non-TopoLVM deployments, it is not needed here.
 :::
@@ -182,7 +186,7 @@ All PVs should show `Available` status before proceeding.
 ## Step 3 (Optional): Configure ClickHouse Storage Path on Read-Only Filesystems \{#step-3-optional-configure-clickhouse-storage-path-on-read-only-filesystems}
 
 :::info
-This step is only needed if you have the query-analytics plugin deployed and want slow query logging / query analysis features. If you do not use query analytics, skip this step — MySQL-MGR instances will function normally without it.
+This step is only needed if you plan to use query analytics features (slow query logging, query analysis). If you do not use query analytics, skip this step — MySQL-MGR instances will function normally without it.
 :::
 
 The query-analytics plugin deploys ClickHouse using a host directory PV. By default, the host path is `/cpaas/ck`. On MicroOS or other systems with a read-only root filesystem, this causes ClickHouse pods to fail with:
@@ -191,15 +195,21 @@ The query-analytics plugin deploys ClickHouse using a host directory PV. By defa
 mkdir /cpaas: read-only file system
 ```
 
-To fix this, set the `hostPath` field in the `RdsInstaller` CR's `spec.slowSQLCK` section to a writable path before deploying the query-analytics plugin:
+:::warning
+You must configure the `hostPath` **before** installing the query-analytics-operator. Once installed, the operator immediately reconciles and creates the ClickHouse PV with the default `/cpaas/ck` path, which will fail on read-only filesystems.
+:::
 
-1. Find the `RdsInstaller` resource:
+### Configure hostPath before installing query-analytics-operator
+
+1. Install the **rds-operator** first (if not already installed). The `RdsInstaller` CR is created by the rds-operator during its initialization.
+
+2. Find the `RdsInstaller` resource:
 
     ```bash
     kubectl get rdsinstaller -A
     ```
 
-2. Edit the `RdsInstaller` to override the ClickHouse host path:
+3. Edit the `RdsInstaller` to override the ClickHouse host path:
 
     ```bash
     kubectl edit rdsinstaller <name> -n <namespace>
@@ -217,14 +227,22 @@ To fix this, set the `hostPath` field in the `RdsInstaller` CR's `spec.slowSQLCK
     On MicroOS, use a path under `/opt/` (e.g., `/opt/local-pv/ck`). The directory will be created automatically with `DirectoryOrCreate` type.
     :::
 
-3. If the query-analytics plugin was already deployed with the default path and ClickHouse pods are failing, update the `hostPath` as above, then recreate the ClickHouse pods:
+4. Now install the **clickhouse-operator** and **query-analytics-operator**. The ClickHouse PV will be created using the configured path instead of the default `/cpaas/ck`.
 
-    ```bash
-    # Find ClickHouse pods
-    kubectl get pod -n <namespace> | grep clickhouse
-    # Delete them to trigger recreation with the new path
-    kubectl delete pod -n <namespace> <clickhouse-pod-names>
-    ```
+### Fix an existing deployment with the wrong hostPath
+
+If the query-analytics-operator was already installed with the default path and ClickHouse pods are failing, update the `hostPath` as above, then delete the existing PV and recreate the ClickHouse pods:
+
+```bash
+# Find and delete the old PV with the wrong hostPath
+kubectl get pv | grep ck
+kubectl delete pv <pv-name>
+
+# Find ClickHouse pods
+kubectl get pod -n <namespace> | grep clickhouse
+# Delete them to trigger recreation with the new path
+kubectl delete pod -n <namespace> <clickhouse-pod-names>
+```
 
 ## Step 4: Create a MySQL-MGR Instance
 

--- a/docs/en/how_to/40-deploy-without-topolvm.mdx
+++ b/docs/en/how_to/40-deploy-without-topolvm.mdx
@@ -132,11 +132,9 @@ NODE2=<node2-hostname>
 NODE3=<node3-hostname>
 
 # Create 3 PVs per node (9 total) to allow for scaling and reprovisioning
-nodes=("$NODE1" "$NODE2" "$NODE3")
-for n in "${!nodes[@]}"; do
-  node="${nodes[$n]}"
+for node in $NODE1 $NODE2 $NODE3; do
   for i in 1 2 3; do
-    idx=$(( n * 3 + i ))
+    idx=$(( ($(echo $NODE1 $NODE2 $NODE3 | tr ' ' '\n' | grep -n $node | cut -d: -f1) - 1) * 3 + i ))
     kubectl apply -f - <<EOF
 apiVersion: v1
 kind: PersistentVolume
@@ -179,50 +177,41 @@ All PVs should show `Available` status before proceeding.
 - Create more PVs than the minimum required to accommodate scaling and reprovisioning. However, extra PVs do not help with failover: if a node is lost, the PVs bound to it cannot be migrated. Recovery from node loss requires manual reprovisioning and data resync.
 :::
 
-## Step 3 (Optional): Configure ClickHouse Storage Path on Read-Only Filesystems \{#step-3-optional-configure-clickhouse-storage-path-on-read-only-filesystems}
+## Step 3 (Optional): Fix ClickHouse Storage on Read-Only Filesystems
 
 :::info
 This step is only needed if you have the query-analytics plugin deployed and want slow query logging / query analysis features. If you do not use query analytics, skip this step — MySQL-MGR instances will function normally without it.
 :::
 
-The query-analytics plugin deploys ClickHouse using a host directory PV. By default, the host path is `/cpaas/ck`. On MicroOS or other systems with a read-only root filesystem, this causes ClickHouse pods to fail with:
+The query-analytics plugin deploys ClickHouse using host directory PVs with a hardcoded path (`/cpaas/ck`). On MicroOS or other systems with a read-only root filesystem, this causes ClickHouse pods to fail with:
 
 ```
 mkdir /cpaas: read-only file system
 ```
 
-To fix this, set the `hostPath` field in the `RdsInstaller` CR's `spec.slowSQLCK` section to a writable path before deploying the query-analytics plugin:
+To fix this, modify the query-analytics instance (`qai` resource) after the query-analytics plugin is deployed:
 
-1. Find the `RdsInstaller` resource:
-
-    ```bash
-    kubectl get rdsinstaller -A
-    ```
-
-2. Edit the `RdsInstaller` to override the ClickHouse host path:
+1. Find the `qai` resource and inspect its current configuration:
 
     ```bash
-    kubectl edit rdsinstaller <name> -n <namespace>
+    kubectl get qai -A
+    kubectl get qai <qai-name> -n <namespace> -o yaml | grep -A5 slowsql
     ```
 
-    Set `spec.slowSQLCK.hostPath` to a writable path on the node:
+2. Edit the `qai` resource and set the `storageClassName` field under `slowsql` to your StorageClass:
 
-    ```yaml
-    spec:
-      slowSQLCK:
-        hostPath: /opt/local-pv/ck
+    ```bash
+    kubectl edit qai <qai-name> -n <namespace>
     ```
 
-    :::info
-    On MicroOS, use a path under `/opt/` (e.g., `/opt/local-pv/ck`). The directory will be created automatically with `DirectoryOrCreate` type.
-    :::
+    Change the `slowsql` section's `storageClassName` to `mgr-local-pv` (or your StorageClass name).
 
-3. If the query-analytics plugin was already deployed with the default path and ClickHouse pods are failing, update the `hostPath` as above, then recreate the ClickHouse pods:
+3. Find and recreate the ClickHouse pods to pick up the new storage configuration:
 
     ```bash
     # Find ClickHouse pods
     kubectl get pod -n <namespace> | grep clickhouse
-    # Delete them to trigger recreation with the new path
+    # Delete them to trigger recreation
     kubectl delete pod -n <namespace> <clickhouse-pod-names>
     ```
 
@@ -287,12 +276,12 @@ To fix this, set the `hostPath` field in the `RdsInstaller` CR's `spec.slowSQLCK
             character_set_server: utf8mb4
             default_storage_engine: InnoDB
             default_time_zone: "+08:00"
+      passwordSecretName: mgr-${instance_name}-password
       version: "8.0"
     EOF
     ```
 
     :::info
-    - The password secret must follow the naming convention `mgr-${instance_name}-password`. The operator discovers it automatically by this name.
     - Set `storageClassName: mgr-local-pv` (or your StorageClass name) in the `volumeClaimTemplate` section. This replaces the default `sc-topolvm`.
     - The `version` field is required. Use `"8.0"` for MySQL 8.0.
     :::
@@ -384,6 +373,6 @@ kubectl annotate mysql ${instance_name} -n ${namespace} \
 
 **Symptom**: ClickHouse pods fail to start with `mkdir /cpaas: read-only file system`.
 
-**Cause**: The query-analytics plugin's default ClickHouse host path (`/cpaas/ck`) does not exist on read-only filesystems.
+**Cause**: The query-analytics plugin uses a hardcoded host path (`/cpaas/ck`) that does not exist on read-only filesystems.
 
-**Fix**: Follow [Step 3](#step-3-optional-configure-clickhouse-storage-path-on-read-only-filesystems) to set `spec.slowSQLCK.hostPath` in the `RdsInstaller` CR to a writable path.
+**Fix**: Follow [Step 3](#step-3-optional-fix-clickhouse-storage-on-read-only-filesystems) to update the `qai` resource with the correct StorageClass.

--- a/docs/en/how_to/40-deploy-without-topolvm.mdx
+++ b/docs/en/how_to/40-deploy-without-topolvm.mdx
@@ -183,7 +183,7 @@ All PVs should show `Available` status before proceeding.
 - Create more PVs than the minimum required to accommodate scaling and reprovisioning. However, extra PVs do not help with failover: if a node is lost, the PVs bound to it cannot be migrated. Recovery from node loss requires manual reprovisioning and data resync.
 :::
 
-## Step 3 (Optional): Configure ClickHouse Storage Path on Read-Only Filesystems {/* #step-3-optional-configure-clickhouse-storage-path-on-read-only-filesystems */}
+## Step 3 (Optional): Configure ClickHouse Storage Path on Read-Only Filesystems \{#step-3-optional-configure-clickhouse-storage-path-on-read-only-filesystems}
 
 :::info
 This step is only needed if you plan to use query analytics features (slow query logging, query analysis). If you do not use query analytics, skip this step — MySQL-MGR instances will function normally without it.

--- a/docs/en/how_to/40-deploy-without-topolvm.mdx
+++ b/docs/en/how_to/40-deploy-without-topolvm.mdx
@@ -229,7 +229,7 @@ You must configure the `hostPath` **before** installing the query-analytics-oper
 
 4. Now install the **clickhouse-operator** and **query-analytics-operator**. The ClickHouse PV will be created using the configured path instead of the default `/cpaas/ck`.
 
-### Fix an existing deployment with the wrong hostPath
+### Fix an existing deployment with the wrong hostPath \{#fix-an-existing-deployment-with-the-wrong-hostpath}
 
 If the query-analytics-operator is already installed with the default path and ClickHouse pods are failing, editing only `RdsInstaller.spec.slowSQLCK.hostPath` is not enough — the merge into `QueryAnalyticsInstaller` only runs when `qai` is first created. You must also force `qai` to be recreated (or edit `qai` directly).
 


### PR DESCRIPTION
## Summary
- Add how-to guide for deploying MySQL-MGR on clusters without TopoLVM (e.g., MicroOS with read-only root FS)
- Covers local StorageClass creation, manual PV provisioning, ClickHouse hostPath configuration, and instance creation
- Clarifies that `spec.slowSQLCK.hostPath` must be set on RdsInstaller **before** installing query-analytics-operator on read-only filesystems (MIDDLEWARE-27539)

## Related
- rds-operator !861 — adds `hostPath` field to `SlowSQL` spec
- query-analytics-operator !55 — propagates `hostPath` to ClickHouse PV template
- rds-operator !867 — cherry-pick to `release-4.3`
- JIRA: MIDDLEWARE-27539

## Test plan
- [x] Verified on ACP cluster test-415 (81.71.35.154): setting hostPath=/opt/local-pv/ck resolves `mkdir /cpaas: read-only file system` mount error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated deployment guide: added prominent warning blocks and restructured Step 3 to emphasize setting the ClickHouse hostPath before installing query analytics. 
  * Introduced a pre-install procedure sequence (install rds operator → configure hostPath → install ClickHouse and query analytics).
  * Added recovery section with two options to fix existing query-analytics installs and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->