### PR TITLE
docs: migrate MGR how-to runbooks from internal Confluence (11 pages)

### DIFF
--- a/docs/en/how_to/100-enable-mysql-plugins.mdx
+++ b/docs/en/how_to/100-enable-mysql-plugins.mdx
@@ -1,0 +1,254 @@
+---
+weight: 100
+i18n:
+  title:
+    en: Enable MySQL Plugins on an MGR Cluster
+    zh: 在 MGR 集群上启用 MySQL 插件
+title: Enable MySQL Plugins on an MGR Cluster
+kind:
+   - Solution
+products:
+  - Alauda Application Services
+productsVersion:
+  - 4.x
+---
+
+# Enable MySQL Plugins on an MGR Cluster
+
+This page covers enabling MySQL server plugins on an MGR cluster managed by Alauda Application Services. It distinguishes the two common scenarios: enabling a built-in plugin that already ships in the MGR image, and shipping a custom plugin shared object via an init container.
+
+## Background
+
+MySQL loads server plugins from the directory pointed to by the `plugin_dir` system variable. The MGR image bundles the upstream and Percona-distributed plugins in `/usr/lib64/mysql/plugin/` (audit log, keyring, validate_password, semisync, group_replication, clone, etc.), so most enablement work amounts to flipping `plugin_load_add` on at server start.
+
+On v4.x the operator surfaces plugin configuration through `spec.params.mysql.mysqld` on the `Mysql` CR. Custom plugin shared objects are delivered by patching the `mysql` container Pod spec via `spec.mgr.patches.podPatches.mysql`.
+
+Legacy paths (`spec.paras`, `spec.mgr.paras`, `spec.mgr.configuration`) still work for backward compatibility but are not the recommended entry point on v4.x — prefer the paths shown below.
+
+## Inspect the bundled plugins
+
+Connect to the `mysql` container of any cluster member and read `plugin_dir`:
+
+```bash
+kubectl exec -it <cluster>-mgr-0 -n <namespace> -c mysql -- \
+  mysql -uroot -p"$MYSQL_ROOT_PASSWORD" -e "SHOW VARIABLES LIKE 'plugin_dir';"
+```
+
+Sample output:
+
+```text
++---------------+--------------------------+
+| Variable_name | Value                    |
++---------------+--------------------------+
+| plugin_dir    | /usr/lib64/mysql/plugin/ |
++---------------+--------------------------+
+```
+
+List the shared objects available in that directory:
+
+```bash
+kubectl exec -it <cluster>-mgr-0 -n <namespace> -c mysql -- \
+  ls -lh /usr/lib64/mysql/plugin/
+```
+
+The image ships a broad selection including `audit_log.so`, `audit_log_filter.so`, `keyring_file.so`, `keyring_vault.so`, `component_keyring_kmip.so`, `validate_password.so`, `connection_control.so`, `semisync_source.so`, `group_replication.so`, `mysql_clone.so`, and the various authentication plugins.
+
+List the plugins currently loaded by the running server:
+
+```sql
+SELECT PLUGIN_NAME, PLUGIN_STATUS, PLUGIN_TYPE, LOAD_OPTION
+FROM information_schema.PLUGINS
+ORDER BY PLUGIN_TYPE, PLUGIN_NAME;
+```
+
+## Enable a built-in plugin
+
+To load a plugin that already ships in the image, set `plugin_load_add` under `spec.params.mysql.mysqld` and add any plugin-specific options on the same level. Multiple plugins can be enabled by separating shared object names with a semicolon: `plugin_load_add: "plugin_a.so;plugin_b.so"`.
+
+Example — enable the Percona audit log plugin with a CSV format and a login-only policy:
+
+```yaml
+apiVersion: mysql.middleware.alauda.io/v1
+kind: Mysql
+metadata:
+  name: <cluster>
+  namespace: <namespace>
+spec:
+  params:
+    mysql:
+      mysqld:
+        plugin_load_add: "audit_log.so"
+        loose_audit_log_exclude_accounts: "exporter@localhost,healthchecker@localhost,manage@localhost,clusterchecker@%"
+        loose_audit_log_format: "CSV"
+        loose_audit_log_policy: "LOGINS"
+```
+
+:::info
+The `loose_` prefix on audit options ensures the server keeps starting even if the plugin is not loaded yet on the very first boot. Once `plugin_load_add` is in effect on subsequent restarts, the prefixed options apply normally.
+:::
+
+Apply the change and wait for the operator to roll the StatefulSet:
+
+```bash
+kubectl apply -f mysql.yaml
+kubectl rollout status -n <namespace> statefulset/<cluster>-mgr
+```
+
+## Enable a custom plugin
+
+Custom plugins ship as additional `.so` files that must be present in `plugin_dir` before the server starts. Use an init container to stage the binary into a shared `emptyDir` volume, mount that volume into the `mysql` container, and point `plugin_dir` at the staged path.
+
+### Pattern 1 — copy from a hostPath
+
+Use this when the plugin binary is pre-staged under a known directory on every node (for example, by a cluster-wide DaemonSet or external provisioning step). The init container copies the binary into the `emptyDir` shared with `mysql`.
+
+```yaml
+apiVersion: mysql.middleware.alauda.io/v1
+kind: Mysql
+metadata:
+  name: <cluster>
+  namespace: <namespace>
+spec:
+  params:
+    mysql:
+      mysqld:
+        plugin_dir: "/tmp/plugin"
+        plugin_load_add: "audit_log_my.so"
+        loose_audit_log_exclude_accounts: "exporter@localhost,healthchecker@localhost,manage@localhost,clusterchecker@%"
+        loose_audit_log_format: "CSV"
+        loose_audit_log_policy: "LOGINS"
+  mgr:
+    patches:
+      podPatches:
+        mysql:
+          spec:
+            containers:
+              - name: mysql
+                volumeMounts:
+                  - mountPath: /tmp/plugin
+                    name: plugin
+            initContainers:
+              - name: copy-community-plugins
+                image: build-harbor.alauda.cn/middleware/rds-operator:<tag>
+                imagePullPolicy: IfNotPresent
+                command:
+                  - sh
+                  - -c
+                  - cp -r /host-plugin/* /plugin/ && chmod -R +x /plugin
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 500Mi
+                  requests:
+                    cpu: 100m
+                    memory: 500Mi
+                securityContext:
+                  runAsNonRoot: false
+                terminationMessagePolicy: FallbackToLogsOnError
+                volumeMounts:
+                  - mountPath: /plugin/
+                    name: plugin
+                  - mountPath: /host-plugin/
+                    name: host-plugin
+            volumes:
+              - name: host-plugin
+                hostPath:
+                  path: /plugin
+                  type: Directory
+              - name: plugin
+                emptyDir: {}
+```
+
+### Pattern 2 — download with an init container
+
+Use this when the plugin binary is hosted on an internal HTTP/S endpoint that the cluster can reach. The init container fetches the binary into the shared `emptyDir`.
+
+```yaml
+spec:
+  params:
+    mysql:
+      mysqld:
+        plugin_dir: "/tmp/plugin"
+        plugin_load_add: "audit_log_my.so"
+        loose_audit_log_exclude_accounts: "exporter@localhost,healthchecker@localhost,manage@localhost,clusterchecker@%"
+        loose_audit_log_format: "CSV"
+        loose_audit_log_policy: "LOGINS"
+  mgr:
+    patches:
+      podPatches:
+        mysql:
+          spec:
+            containers:
+              - name: mysql
+                resources: {}
+                volumeMounts:
+                  - mountPath: /tmp/plugin
+                    name: plugin
+            initContainers:
+              - name: copy-community-plugins
+                image: build-harbor.alauda.cn/middleware/rds-operator:<tag>
+                imagePullPolicy: IfNotPresent
+                command:
+                  - sh
+                  - -c
+                  - wget http://<host>:<port>/audit_log_my.so -O /plugin/audit_log_my.so && chmod +x /plugin/audit_log_my.so
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 500Mi
+                  requests:
+                    cpu: 100m
+                    memory: 500Mi
+                securityContext:
+                  runAsNonRoot: false
+                terminationMessagePolicy: FallbackToLogsOnError
+                volumeMounts:
+                  - mountPath: /plugin/
+                    name: plugin
+            volumes:
+              - name: plugin
+                emptyDir: {}
+```
+
+:::warning
+`podPatches.mysql` requires a `containers: [{name: mysql}]` stub even when you only need to add init containers or volumes — the patch is keyed on the container name and the operator will reject a patch that does not list the target container.
+:::
+
+The `volumes` and `volumeMounts` shown above only declare the entries needed for the plugin staging area. The default `mysql` container already has its own volumes (data PVC, config, secrets) managed by the operator — your patch is merged on top, so you do not need to repeat them. If in doubt, create a default cluster first and inspect the resulting StatefulSet:
+
+```bash
+kubectl get statefulset <cluster>-mgr -n <namespace> -o yaml
+```
+
+## Verify
+
+After the StatefulSet has rolled, confirm the plugin is loaded and active:
+
+```sql
+SELECT * FROM information_schema.PLUGINS WHERE PLUGIN_NAME LIKE '%audit%'\G
+```
+
+Expected output for the Percona audit plugin:
+
+```text
+*************************** 1. row ***************************
+           PLUGIN_NAME: audit_log
+        PLUGIN_VERSION: 0.2
+         PLUGIN_STATUS: ACTIVE
+           PLUGIN_TYPE: AUDIT
+   PLUGIN_TYPE_VERSION: 4.1
+        PLUGIN_LIBRARY: audit_log.so
+PLUGIN_LIBRARY_VERSION: 1.11
+         PLUGIN_AUTHOR: Percona LLC and/or its affiliates.
+    PLUGIN_DESCRIPTION: Audit log
+        PLUGIN_LICENSE: GPL
+           LOAD_OPTION: ON
+```
+
+If `PLUGIN_STATUS` is not `ACTIVE`, check the `mysql` container's error log for plugin load errors:
+
+```bash
+kubectl logs -n <namespace> <cluster>-mgr-0 -c mysql | grep -i plugin
+```
+
+Typical failure causes are a missing or non-executable `.so` file in `plugin_dir`, an ABI mismatch between the plugin and the MySQL release shipped in the MGR image, or a required dependent option that was not set under `spec.params.mysql.mysqld`.

--- a/docs/en/how_to/105-restore-mgr-across-namespaces-and-clusters.mdx
+++ b/docs/en/how_to/105-restore-mgr-across-namespaces-and-clusters.mdx
@@ -1,0 +1,211 @@
+---
+weight: 105
+i18n:
+  title:
+    en: Restore MGR Across Namespaces and Clusters
+    zh: MGR 跨命名空间与跨集群恢复方案
+title: Restore MGR Across Namespaces and Clusters
+kind:
+   - Solution
+products:
+  - Alauda Application Services
+productsVersion:
+  - 4.x
+---
+
+# Restore MGR Across Namespaces and Clusters
+
+When a backup taken from one MGR cluster needs to be restored into a different namespace, or even a different Kubernetes cluster, the default `MySQLRestore` flow — which assumes the backup CR lives in the same namespace as the restore target — is not sufficient. This how-to covers the two cross-boundary recipes: a namespace-level restore when both source and target namespaces are reachable, and a cluster-level restore that uses a synthetic `MySQLMeta` resource when the source namespace is unreachable.
+
+## Background
+
+Each MGR backup writes two artifacts to S3:
+
+- the data archive (`.tar.zst`)
+- a `<backup>-meta.yaml` sidecar that mirrors the in-cluster `MySQLBackup` CR's `status` block.
+
+When the source `MySQLBackup` CR is reachable, the operator reads the status directly from it. When it is not, the equivalent status is reconstructed locally as a `MySQLMeta` resource that points at the same S3 prefix; the operator then drives the restore from that surrogate.
+
+This procedure requires backups produced by the `mysqlsh` executor (default in v4.x). Older `mysqldump`-based backups are not compatible.
+
+## Prerequisites
+
+- Both source and target sides take backups against the same S3 endpoint, bucket, and credentials.
+- The target side has the S3 storage configured under **Backup Center → External S3 Storage** using the same name that was used on the source side.
+- The target `Mysql` cluster (called `new` in the examples) already exists in the target namespace (`tsl-o`).
+
+## Cross-namespace restore
+
+Use this flow when the source namespace lives in the same Kubernetes cluster and the source `MySQLBackup` CRs are reachable from the target namespace. Set `spec.source.namespace` on the `MySQLRestore` CR to the namespace that holds the source backup.
+
+### Restore from a specific full backup
+
+```yaml
+apiVersion: mysql.middleware.alauda.io/v1
+kind: MySQLRestore
+metadata:
+  name: mgr-ns-bk
+  namespace: tsl-o
+spec:
+  backup:
+    name: mgr-full
+  cluster:
+    name: new
+  source:
+    name: mgr
+    namespace: tsl-x
+    type: cluster
+```
+
+### Point-in-time restore
+
+`timePoint` accepts any timestamp covered by an incremental backup. The valid range is visible on the source instance's restore page in the UI, or by inspecting the source `MySQLBackup` CRs' `status.validTimeRange`.
+
+```yaml
+apiVersion: mysql.middleware.alauda.io/v1
+kind: MySQLRestore
+metadata:
+  name: mgr-ns-tp
+  namespace: tsl-o
+spec:
+  cluster:
+    name: new
+  source:
+    name: mgr
+    namespace: tsl-x
+    type: cluster
+  timePoint: "2024-04-15T07:26:27Z"
+```
+
+## Cross-cluster restore
+
+Use this flow when the source namespace is unreachable — for example, the source cluster has been retired or only the S3 bucket has survived.
+
+### 1. Create a `MySQLMeta` placeholder
+
+In the target namespace, create an empty `MySQLMeta`. Pick a name that does **not** collide with the target instance name and is **not** of the form `<instance>-meta` — both are reserved by the operator for internal bookkeeping.
+
+```yaml
+apiVersion: mysql.middleware.alauda.io/v1
+kind: MySQLMeta
+metadata:
+  name: mgr-meta-o
+  namespace: tsl-o
+spec: {}
+```
+
+### 2. Populate the meta status from the S3 sidecar
+
+In S3, locate the source instance's backup prefix and download the `<backup>-meta.yaml` file. Copy the entire top-level `status:` block out of it.
+
+Open the `MySQLMeta` status subresource and paste:
+
+```bash
+kubectl -n tsl-o edit --subresource status mysqlmeta mgr-meta-o
+```
+
+A populated status looks like this (one full backup plus one incremental backup):
+
+```yaml
+status:
+  cluster: mgr
+  tidyBackup: mgr-incr
+  validTimeRange:
+    - endIndex: 1
+      endTime: "2024-04-15T07:26:27Z"
+      startTime: "2024-04-15T07:22:18Z"
+  backupInfos:
+    - name: mgr-full
+      spec:
+        cluster:
+          name: mgr
+        storage:
+          s3:
+            bucket: data
+            endpoint: http://127.0.0.1:19000
+            secret:
+              name: backup-s3
+        type: full
+      status:
+        allocated: mgr-0
+        dataEndTime: "2024-04-15T07:22:13Z"
+        executor: mysqlsh
+        finishTime: "2024-04-15T07:22:13Z"
+        gtidEnd: 4940c3be-faf8-11ee-9e9a-000000ed26ce:114
+        memberSize: 1
+        path: mgr/tsl-x/mgr/full/backup-2024-04-15T07:22:12Z.tar.zst
+        startTime: "2024-04-15T07:22:12Z"
+        state: succeeded
+    - name: mgr-incr
+      spec:
+        cluster:
+          name: mgr
+        storage:
+          s3:
+            bucket: data
+            endpoint: http://81.68.232.254:19000
+            secret:
+              name: backup-s3
+        type: incr
+      status:
+        allocated: mgr-0
+        dataEndTime: "2024-04-15T07:26:27Z"
+        dataStartTime: "2024-04-15T07:22:18Z"
+        executor: mysqlsh
+        finishTime: "2024-04-15T07:26:32Z"
+        gtidEnd: 4940c3be-faf8-11ee-9e9a-000000ed26ce:160
+        gtidFullPrevious: 4940c3be-faf8-11ee-9e9a-000000ed26ce:114
+        gtidPrevious: 4940c3be-faf8-11ee-9e9a-000000ed26ce:114
+        gtidStart: 4940c3be-faf8-11ee-9e9a-000000ed26ce:115
+        memberSize: 1
+        path: mgr/tsl-x/mgr/incr/backup-2024-04-15T07:26:31Z.tar.zst
+        startTime: "2024-04-15T07:26:31Z"
+        state: succeeded
+```
+
+### 3. Create the restore against the meta
+
+Reference the `MySQLMeta` as `source.type: meta`.
+
+#### Restore from a specific full backup
+
+```yaml
+apiVersion: mysql.middleware.alauda.io/v1
+kind: MySQLRestore
+metadata:
+  name: mgr-cs-bk
+  namespace: tsl-o
+spec:
+  backup:
+    name: mgr-full
+  cluster:
+    name: new
+  source:
+    name: mgr-meta-o
+    type: meta
+```
+
+#### Point-in-time restore
+
+```yaml
+apiVersion: mysql.middleware.alauda.io/v1
+kind: MySQLRestore
+metadata:
+  name: mgr-cs-tp
+  namespace: tsl-o
+spec:
+  cluster:
+    name: new
+  source:
+    name: mgr-meta-o
+    type: meta
+  timePoint: "2024-04-15T07:26:27Z"
+```
+
+The operator reads the backup metadata from the `MySQLMeta` status, downloads the artifacts from S3, and restores them into the `new` cluster in the target namespace. Monitor progress with:
+
+```bash
+kubectl -n tsl-o get mysqlrestore mgr-cs-bk -o yaml
+```
+
+The restore is finished when `.status.phase` reaches `succeeded`.

--- a/docs/en/how_to/110-restore-specific-databases-and-tables.mdx
+++ b/docs/en/how_to/110-restore-specific-databases-and-tables.mdx
@@ -1,0 +1,91 @@
+---
+weight: 110
+i18n:
+  title:
+    en: Restore Specific Databases and Tables from an MGR Backup
+    zh: MGR 指定库表备份恢复
+title: Restore Specific Databases and Tables from an MGR Backup
+kind:
+   - Solution
+products:
+  - Alauda Application Services
+productsVersion:
+  - 4.x
+---
+
+# Restore Specific Databases and Tables from an MGR Backup
+
+When a logical mistake — a dropped table, a bad bulk update — needs to be undone, restoring the entire cluster from a full backup is overkill. The MGR operator's `mysqlsh`-based backup format supports selective restore of individual schemas or tables into a fresh target cluster, leaving the rest of the source dataset untouched. This how-to walks through the `MySQLRestore` fields that drive the selection and shows how to validate the result.
+
+## Background
+
+A full backup taken by the operator's `mysqlsh` executor (default in v4.x) is a MySQL Shell dump. Shell dumps support partial-load filters at restore time. The `MySQLRestore` CR exposes those filters under `spec.mysqlShellLoad`:
+
+- `includeSchemas` — restore only the listed databases.
+- `includeTables` — restore only the listed tables, with names written in `schema.table` form.
+
+The restore is applied into the **target** cluster named under `spec.cluster.name`. The target is typically a freshly-created empty `Mysql` instance.
+
+## Prerequisites
+
+- Source and target instances both run v4.x of the operator.
+- The full backup referenced by `spec.backup.name` was produced by the `mysqlsh` executor. Check `status.executor` on the source `MySQLBackup` CR to confirm.
+- The target cluster is healthy with at least one ONLINE PRIMARY.
+
+## Procedure
+
+### 1. Create the `MySQLRestore` resource
+
+```yaml
+apiVersion: mysql.middleware.alauda.io/v1
+kind: MySQLRestore
+metadata:
+  name: restore-full-tables
+  namespace: tsl-x
+spec:
+  backup:
+    name: mgr-all
+  cluster:
+    name: new
+  source:
+    name: mgr
+  mysqlShellLoad:
+    includeSchemas:
+      - fu
+    includeTables:
+      - fu.user
+```
+
+Field meaning:
+
+- `spec.backup.name` — the `MySQLBackup` CR holding the full backup to restore from.
+- `spec.source.name` — the source `Mysql` instance the backup belongs to.
+- `spec.cluster.name` — the target `Mysql` instance that receives the restored data.
+- `spec.mysqlShellLoad.includeSchemas` — schemas to restore. Schemas not listed here are skipped.
+- `spec.mysqlShellLoad.includeTables` — tables to restore, in `schema.table` form. Tables inside the listed schemas but not enumerated here are skipped.
+
+If every table inside a schema should be restored, omit `includeTables` and rely on `includeSchemas` alone. If `includeTables` is set, every table you want must be enumerated — table names without a schema prefix are rejected.
+
+### 2. Watch the restore complete
+
+```bash
+kubectl -n tsl-x get mysqlrestore restore-full-tables -w
+```
+
+The restore is finished when the CR transitions to the `ready` state.
+
+### 3. Validate
+
+Connect to the target cluster's read-write endpoint and verify that only the requested schemas and tables exist:
+
+```bash
+kubectl -n tsl-x exec -it new-0 -c mysql -- \
+  mysql -uroot -p"$MYSQL_PASSWORD" \
+        -e "SHOW DATABASES; SELECT COUNT(*) FROM fu.user;"
+```
+
+To rehearse the workflow end-to-end on a sandbox:
+
+1. Create several databases on the source MGR cluster and trigger a full backup.
+2. Apply the `MySQLRestore` shown above against a freshly-created empty target cluster.
+3. After the restore reaches `ready`, confirm that only the listed schemas and tables exist in the target.

--- a/docs/en/how_to/115-repair-myisam-and-missing-pk-tables.mdx
+++ b/docs/en/how_to/115-repair-myisam-and-missing-pk-tables.mdx
@@ -1,0 +1,162 @@
+---
+weight: 115
+i18n:
+  title:
+    en: Repair MyISAM and Missing-Primary-Key Tables on MGR
+    zh: 修复 MGR 集群中误用 MyISAM 引擎或缺失主键的表
+title: Repair MyISAM and Missing-Primary-Key Tables on MGR
+kind:
+   - Solution
+products:
+  - Alauda Application Services
+productsVersion:
+  - 4.x
+---
+
+# Repair MyISAM and Missing-Primary-Key Tables on MGR
+
+Group Replication only supports `InnoDB` tables with a defined primary key. If a member of the cluster leaves the group and the operator's `addInstance` or `rejoinInstance` operation fails complaining about a MyISAM table or a table without a primary key, this page describes how to bring the cluster back to a healthy state.
+
+## Background
+
+Group Replication requires that every replicated table:
+
+- uses the `InnoDB` storage engine — MGR's certifier and applier modules rely on InnoDB's transactional and row-image semantics; and
+- has an explicit primary key (or a unique non-null key that the server can promote to one), so that row events can be replayed deterministically on other members.
+
+A member that joins the group with a MyISAM table or a table without a primary key fails the join check and is dropped back out of the group.
+
+:::info
+On Alauda Application Services 4.x (audited on v4.3.2, 2026-05-15), the default `Mysql` parameter template ships with:
+
+- `disabled_storage_engines: "MyISAM,MEMORY,CSV,ARCHIVE,BLACKHOLE,FEDERATED"` — `CREATE TABLE ... ENGINE=MyISAM` is rejected by the server.
+- `sql_generate_invisible_primary_key: "ON"` — any table created without a primary key automatically gets an invisible primary key column.
+
+Both failure modes covered on this page are therefore **prevented by default on v4.x**. The procedure below is only relevant if your `Mysql` CR has explicitly overridden one or both of those settings — for example via `spec.params.mysql.mysqld.disabled_storage_engines` or `spec.params.mysql.mysqld.sql_generate_invisible_primary_key` — and the cluster has subsequently accepted a MyISAM table or a table without a primary key.
+:::
+
+## Diagnose
+
+When `mysql-mgr-operator` retries `addInstance` / `rejoinInstance` on a member that has left the group, look at the `mysql` container log on that member.
+
+A MyISAM violation surfaces as:
+
+```text
+[ERROR] [Repl] Plugin group_replication reported: 'Table 'test.myisam_table' uses the MyISAM storage engine which is not supported by Group Replication. Please convert it to an InnoDB table.'
+[ERROR] [Repl] Plugin group_replication reported: 'The member is unable to join the group because it has tables using the MyISAM storage engine.'
+[ERROR] [Repl] Plugin group_replication reported: 'The member will now leave the group.'
+```
+
+A missing primary key surfaces as:
+
+```text
+[ERROR] [Repl] Plugin group_replication reported: 'Table 'test.no_pk_table' does not have a PRIMARY KEY. This is not compatible with Group Replication.'
+[ERROR] [Repl] Plugin group_replication reported: 'The member is unable to join the group because it has tables without a PRIMARY KEY.'
+[ERROR] [Repl] Plugin group_replication reported: 'The member will now leave the group.'
+```
+
+Collect the full list of offending tables before starting the repair — the same error is logged once per table.
+
+## Resolution
+
+Because an MGR cluster in this state cannot accept writes anyway, the simplest fix is to drop the offending (empty) tables on every member. If the tables hold data you wish to preserve, see the alternatives at the end of this page.
+
+### 1. Stop the operator from reconciling
+
+Scale the MGR operator deployment to zero so it does not interfere with the manual session settings below:
+
+```bash
+kubectl scale -n mgr-system deployment mysql-mgr-operator --replicas=0
+kubectl rollout status -n mgr-system deployment mysql-mgr-operator
+```
+
+### 2. Drop the offending tables on every member
+
+For each `mysql` pod (`<cluster>-mgr-0`, `<cluster>-mgr-1`, `<cluster>-mgr-2`), connect to the local server and drop the offending tables. The session disables `super_read_only` and pauses GTID recording so the DROP does not generate a binlog transaction that the other members would also try to apply:
+
+```bash
+kubectl exec -it <cluster>-mgr-N -n <namespace> -c mysql -- \
+  mysql -uroot -p"$MYSQL_ROOT_PASSWORD"
+```
+
+```sql
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL gtid_mode = OFF;
+
+DROP TABLE test.myisam_table1, test.myisam_table2;
+
+SET @@GLOBAL.gtid_mode = ON;
+SET GLOBAL super_read_only = ON;
+```
+
+Repeat on every member. Do not skip the `gtid_mode` toggles — without them the DROP records a GTID that the other members would re-apply, defeating the purpose of fixing each member locally.
+
+### 3. Resume the operator
+
+```bash
+kubectl scale -n mgr-system deployment mysql-mgr-operator --replicas=1
+kubectl rollout status -n mgr-system deployment mysql-mgr-operator
+```
+
+### 4. Wait for the cluster to self-heal
+
+The operator's next reconciliation will retry `addInstance` / `rejoinInstance` for the departed members. Verify membership recovers:
+
+```sql
+SELECT MEMBER_HOST, MEMBER_STATE, MEMBER_ROLE
+FROM performance_schema.replication_group_members;
+```
+
+All three rows should be `ONLINE`, with exactly one `PRIMARY` in single-primary mode. Re-check the `mysql` container log to make sure no further offending tables remain.
+
+## Alternatives — preserve the data
+
+If the tables contain rows you need to keep, replace step 2's `DROP TABLE` with one of the following.
+
+### MyISAM tables — convert to InnoDB
+
+For each offending table, run on every member (still inside the `super_read_only=OFF; gtid_mode=OFF` block):
+
+```sql
+ALTER TABLE test.myisam_table ENGINE=InnoDB;
+```
+
+Replace `test.myisam_table` with the schema-qualified table name from the error log.
+
+### Tables without a primary key — add one
+
+Either add an auto-increment surrogate key:
+
+```sql
+ALTER TABLE test.no_pk_table ADD COLUMN id INT AUTO_INCREMENT PRIMARY KEY;
+```
+
+Or promote an existing unique, non-null column to the primary key:
+
+```sql
+ALTER TABLE test.no_pk_table ADD PRIMARY KEY (existing_unique_column);
+```
+
+:::warning
+`ALTER TABLE` rewrites the table on disk and runs locally on every member while the cluster is split. Make sure the schemas are identical on every member after you finish — re-run `SHOW CREATE TABLE` on each pod and compare.
+:::
+
+## Prevent recurrence
+
+After recovery, restore the v4 defaults on `spec.params.mysql.mysqld` so future offending DDL is rejected at `CREATE TABLE` time rather than discovered at re-join time:
+
+```yaml
+spec:
+  params:
+    mysql:
+      mysqld:
+        disabled_storage_engines: "MyISAM,MEMORY,CSV,ARCHIVE,BLACKHOLE,FEDERATED"
+        sql_generate_invisible_primary_key: "ON"
+```
+
+Apply the CR, let the operator roll the StatefulSet, then confirm the variables took effect:
+
+```sql
+SHOW GLOBAL VARIABLES WHERE Variable_name IN
+  ('disabled_storage_engines', 'sql_generate_invisible_primary_key');
+```

--- a/docs/en/how_to/60-resolve-startup-failure-on-vms-without-x86-64-v2.mdx
+++ b/docs/en/how_to/60-resolve-startup-failure-on-vms-without-x86-64-v2.mdx
@@ -1,0 +1,99 @@
+---
+weight: 60
+i18n:
+  title:
+    en: Resolve Startup Failure on VMs Without x86-64-v2 Support
+    zh: 解决虚拟机指令集过旧（缺少 x86-64-v2）导致的启动失败
+title: Resolve Startup Failure on VMs Without x86-64-v2 Support
+kind:
+   - Solution
+products:
+  - Alauda Application Services
+productsVersion:
+  - 4.x
+---
+
+# Resolve Startup Failure on VMs Without x86-64-v2 Support
+
+When a MySQL-MGR cluster is deployed on virtual machines whose guest CPU only exposes the legacy x86-64-v1 instruction set, the MGR server containers (and any other component built on a `stream9` base image, including the MGR Operator and ProxySQL) refuse to start with the error:
+
+```
+Fatal glibc error: CPU does not support x86-64-v2
+```
+
+This page explains why, and how to fix it by lifting the guest CPU baseline to at least x86-64-v2.
+
+## Background
+
+The container images shipped with the MGR operator are built on a CentOS Stream 9 base, which (following Red Hat's upstream decision) raised its minimum supported instruction set from x86-64-v1 to x86-64-v2. Any guest that does not advertise x86-64-v2 to the workload will refuse to load glibc on these images.
+
+### Instruction-set generations
+
+| Microarchitecture level | Released | Notable additions | Earliest Intel cores |
+| --- | --- | --- | --- |
+| x86-64-v1 | 2003 | Baseline 64-bit | Pre-Nehalem Xeon |
+| x86-64-v2 | 2005 | SSE3, SSSE3, SSE4.1/4.2, POPCNT | Sandy Bridge / Ivy Bridge |
+| x86-64-v3 | 2011 | AVX, AVX2, BMI1/2, FMA | Haswell / Broadwell |
+| x86-64-v4 | 2014 | AVX-512 | Skylake-X and later |
+
+In practice any physical CPU released after roughly 2011 supports x86-64-v2; the failure almost always indicates that a hypervisor is *masking* a newer CPU down to an older feature set for vMotion / live-migration compatibility.
+
+### Why this is intentional
+
+- x86-64-v1 is more than twenty years old and is no longer present on any current hardware.
+- The MGR images previously tolerated x86-64-v1, but the upstream base image dropped support as part of a security fix, and the project follows that choice.
+- Red Hat publishes the same guidance for RHEL 9 guests (see [solution 6833751](https://access.redhat.com/solutions/6833751)).
+
+:::warning
+Do not attempt to work around this by rebuilding the MGR images on an older base — you will lose the security fixes that motivated the baseline change in the first place.
+:::
+
+## Resolution
+
+The fix is to raise the guest CPU baseline so it advertises x86-64-v2 (or higher). The exact procedure depends on the hypervisor; the most common case in the field is VMware vSphere with Enhanced vMotion Compatibility (EVC).
+
+### VMware vSphere: set EVC to Sandy Bridge or newer
+
+Enhanced vMotion Compatibility (EVC) forces every host in a cluster — or every VM, when set per-VM — to advertise a uniform CPU feature set so live-migration works across mixed hardware. EVC is configured either at the cluster level or per VM. The per-VM setting is preferred when you only need to lift the baseline for the database VMs.
+
+1. In the vSphere Client, navigate to the VM hosting the MGR / MGR-Operator workload.
+2. Power off the VM (EVC mode changes require a powered-off VM).
+3. Open **Configure → VMware EVC** and click **Edit**.
+4. Select **Enable EVC for Intel hosts**, then choose an Intel generation **no earlier than Sandy Bridge**. Any of the following is sufficient:
+
+   | EVC mode | Instruction-set level exposed to guest |
+   | --- | --- |
+   | Nehalem / Westmere | x86-64-v1 (insufficient) |
+   | **Sandy Bridge / Ivy Bridge** | **x86-64-v2 (minimum required)** |
+   | Haswell / Broadwell / Skylake or later | x86-64-v3 or higher |
+
+5. Power the VM back on. The MGR / Operator Pod scheduled on this node should now start cleanly.
+
+For AMD hosts the equivalent EVC tiers are AMD Opteron Gen. 3 ("Greyhound") and newer; pick a generation that maps to x86-64-v2 at minimum.
+
+### Other hypervisors
+
+- **KVM / QEMU / libvirt**: in the domain XML, change `<cpu mode="custom">` to `host-model` or `host-passthrough`, or pick a named model such as `SandyBridge` or newer. After editing, shut the guest down and start it again — a reboot from inside the guest is not enough.
+- **Hyper-V**: disable processor compatibility mode on the VM (`Set-VMProcessor -CompatibilityForMigrationEnabled $false`), or migrate the VM onto a host whose baseline already exposes x86-64-v2.
+- **Other platforms**: consult the [Red Hat KB](https://access.redhat.com/solutions/6833751) — the same guest-side symptom and the same baseline requirement apply.
+
+### Verify from inside the guest
+
+After powering the VM back on, you can confirm the guest now sees the required features:
+
+```bash
+/lib64/ld-linux-x86-64.so.2 --help | grep -E 'x86-64-v[0-9]'
+```
+
+The line for `x86-64-v2` should be marked `(supported, searched)`. Once it is, restart the affected MGR Pod:
+
+```bash
+kubectl -n <namespace> delete pod <mgr-pod-name>
+```
+
+The Pod will be rescheduled by the operator and initialize successfully.
+
+## References
+
+- [VMware EVC overview](https://www.bdrsuite.com/blog/vmware-evc-mode-overview/)
+- [Red Hat KB on the same symptom for RHEL 9 guests](https://access.redhat.com/solutions/6833751)

--- a/docs/en/how_to/65-mysql-tls-support.mdx
+++ b/docs/en/how_to/65-mysql-tls-support.mdx
@@ -1,0 +1,105 @@
+---
+weight: 65
+i18n:
+  title:
+    en: MySQL TLS Support and Diagnostics
+    zh: MySQL TLS 支持情况与诊断
+title: MySQL TLS Support and Diagnostics
+kind:
+   - Solution
+products:
+  - Alauda Application Services
+productsVersion:
+  - 4.x
+---
+
+# MySQL TLS Support and Diagnostics
+
+MySQL 8.0.28 and later only accept `TLSv1.2` and `TLSv1.3` connections by default. Application drivers pinned to `TLSv1` or `TLSv1.1` therefore fail to connect to an MGR cluster running on a recent MySQL 8.0 build. This page explains the upstream default and how to identify sessions still negotiating a deprecated protocol.
+
+## Background
+
+The `tls_version` system variable controls which TLS protocols the MySQL server is willing to negotiate. Upstream defaults changed over the MySQL 8.0 release line:
+
+| MySQL Server release              | `tls_version` default                              |
+| :-------------------------------- | :------------------------------------------------- |
+| 8.0.15 and below                  | `TLSv1,TLSv1.1,TLSv1.2`                            |
+| 8.0.16 – 8.0.27                   | `TLSv1,TLSv1.1,TLSv1.2,TLSv1.3` (with OpenSSL 1.1.1) |
+| 8.0.28 and above                  | `TLSv1.2,TLSv1.3`                                  |
+
+Reference: [MySQL Server TLS Protocol Default Settings](https://dev.mysql.com/doc/refman/8.2/en/encrypted-connection-protocols-ciphers.html#encrypted-connection-protocol-configuration).
+
+The MGR images shipped with Alauda Application Services 4.x are built on MySQL 8.0.28+, so they default to `TLSv1.2,TLSv1.3` and reject legacy protocols.
+
+## Checking the server's TLS protocol set
+
+Connect to any MGR pod and query the variable:
+
+```bash
+kubectl exec -it <mysql-pod> -n <namespace> -c mysql -- \
+  mysql -uroot -p"$MYSQL_ROOT_PASSWORD" -e "SHOW GLOBAL VARIABLES LIKE 'tls_version';"
+```
+
+Expected output for a 4.x MGR cluster:
+
+```text
++---------------+-----------------+
+| Variable_name | Value           |
++---------------+-----------------+
+| tls_version   | TLSv1.2,TLSv1.3 |
++---------------+-----------------+
+```
+
+## Identifying sessions negotiating TLSv1.0 or TLSv1.1
+
+Run the following query against the Primary node. Any rows returned represent sessions that did not negotiate `TLSv1.2` or `TLSv1.3`:
+
+```sql
+SELECT
+  session_ssl_status.thread_id,
+  session_ssl_status.ssl_version,
+  session_ssl_status.ssl_cipher,
+  session_ssl_status.ssl_sessions_reused
+FROM sys.session_ssl_status
+WHERE ssl_version NOT IN ('TLSv1.3','TLSv1.2');
+```
+
+:::info
+Internal MGR replication threads (`group_rpl/THD_applier_module_receiver`, `sql/replica_sql`, `sql/replica_worker`) appear with an empty `ssl_version` because they communicate over the group communication channel rather than a normal client SSL session. They are expected and not a sign of a deprecated client.
+:::
+
+## Listing the application threads and user statements still on legacy TLS
+
+To map a deprecated TLS session back to a user, database, and statement, join `sys.session_ssl_status` with `sys.processlist`:
+
+```sql
+SELECT thd_id, conn_id, user, db, current_statement, program_name
+FROM sys.processlist
+WHERE thd_id IN (
+  SELECT session_ssl_status.thread_id
+  FROM sys.session_ssl_status
+  WHERE ssl_version NOT IN ('TLSv1.3','TLSv1.2')
+);
+```
+
+For a fuller picture (transaction state, last statement, memory usage) use `sys.session`:
+
+```sql
+SELECT *
+FROM sys.session
+WHERE thd_id IN (
+  SELECT session_ssl_status.thread_id
+  FROM sys.session_ssl_status
+  WHERE ssl_version NOT IN ('TLSv1.3','TLSv1.2')
+)\G
+```
+
+## Remediation
+
+If application connections appear with a legacy `ssl_version`, upgrade the affected client driver to a version that negotiates `TLSv1.2` or `TLSv1.3`. Common minimums:
+
+- MySQL Connector/J 8.0.x
+- MySQL Connector/Python 8.0.x
+- libmysqlclient shipped with MySQL 5.7.28+ or 8.0.x
+
+Avoid widening `tls_version` on the server to re-enable `TLSv1` / `TLSv1.1`: those protocols are deprecated upstream and disabled in the MGR base image for compliance reasons.

--- a/docs/en/how_to/70-import-export-data-on-mgr.mdx
+++ b/docs/en/how_to/70-import-export-data-on-mgr.mdx
@@ -85,7 +85,7 @@ kubectl cp <namespace>/<mgr-pod-0>:/var/lib/mysql/<dump-file>.sql ./<dump-file>.
 
    Group Replication propagates the imported transactions to the Secondaries automatically; do not run the import on more than one member.
 
-3. **Recreate application users.** A dump that was prepared with the guidance in [How to Import and Export MySQL Data](../../solutions/How_to_Import_and_Export_MySQL_Data.md) does not contain accounts from the source `mysql` system schema. Create application accounts explicitly on the Primary:
+3. **Recreate application users.** A dump that was prepared with the guidance in the *How to Import and Export MySQL Data* knowledge-base article does not contain accounts from the source `mysql` system schema. Create application accounts explicitly on the Primary:
 
    ```sql
    CREATE USER 'app'@'%' IDENTIFIED BY '<strong-password>';

--- a/docs/en/how_to/70-import-export-data-on-mgr.mdx
+++ b/docs/en/how_to/70-import-export-data-on-mgr.mdx
@@ -1,0 +1,99 @@
+---
+weight: 70
+i18n:
+  title:
+    en: Import and Export Data on an MGR Cluster
+    zh: 在 MGR 集群上进行数据导入导出
+title: Import and Export Data on an MGR Cluster
+kind:
+   - Solution
+products:
+  - Alauda Application Services
+productsVersion:
+  - 4.x
+---
+
+# Import and Export Data on an MGR Cluster
+
+This page covers the MGR-operator-specific steps for moving a logical dump into and out of an MGR cluster managed by Alauda Application Services. The generic `mysqldump` flags and account-handling guidance are covered separately in the solutions knowledge base; this page focuses on what changes when source or destination is a pod under the MGR operator.
+
+## Background
+
+An MGR cluster managed by the operator runs MySQL inside a StatefulSet (`mysql-mgr-<n>`) with two important constraints:
+
+- The only writable path inside the `mysql` container is `/var/lib/mysql` (data directory) and `/var/lib/mysql-files` (designated by `secure_file_priv`). Dumps and imports must be staged into one of those paths.
+- Writes must be directed at the **Primary** member. Connecting to a Secondary in single-primary mode rejects DML.
+
+## Identify the Primary node
+
+Pick any member of the cluster and ask MySQL which member is currently `PRIMARY`:
+
+```bash
+kubectl exec -it <mgr-pod-0> -n <namespace> -c mysql -- \
+  mysql -uroot -hlocalhost -p"$MYSQL_ROOT_PASSWORD" -e \
+  "SELECT MEMBER_HOST, MEMBER_PORT, MEMBER_STATE, MEMBER_ROLE
+   FROM performance_schema.replication_group_members;"
+```
+
+Look for the row with `MEMBER_ROLE = PRIMARY` and use its host (the pod name) for the import steps below.
+
+## Export data from an MGR cluster
+
+The MGR pod images ship a matching `mysqldump`, so the most reliable way to dump from an MGR cluster is to exec into a pod and write the file to the data directory:
+
+```bash
+kubectl exec -it <mgr-pod-0> -n <namespace> -c mysql -- bash -lc '
+  mysqldump \
+    --host=127.0.0.1 \
+    --user=root \
+    --password="$MYSQL_ROOT_PASSWORD" \
+    --single-transaction \
+    --source-data=1 \
+    --set-gtid-purged=AUTO \
+    --triggers --routines --events \
+    --databases <db1> <db2> \
+  > /var/lib/mysql/$(date +%Y%m%d)_fullbackup.sql
+'
+```
+
+Then copy the resulting file out of the pod:
+
+```bash
+kubectl cp <namespace>/<mgr-pod-0>:/var/lib/mysql/<dump-file>.sql ./<dump-file>.sql -c mysql
+```
+
+:::warning
+`/var/lib/mysql` is the live data directory. Delete the dump after copying it out so it does not occupy datafile space or end up in subsequent operator-managed backups.
+:::
+
+## Import a dump into an MGR cluster
+
+1. **Stage the dump file inside the Primary pod.** Copy the `.sql` to `/var/lib/mysql-files/`, which is the directory allowed by `secure_file_priv`:
+
+   ```bash
+   kubectl cp ./<dump-file>.sql <namespace>/<primary-pod>:/var/lib/mysql-files/ -c mysql
+   ```
+
+2. **Run the import against the Primary.** Connect over the local socket and source the dump:
+
+   ```bash
+   kubectl exec -it <primary-pod> -n <namespace> -c mysql -- bash -lc '
+     mysql -uroot -hlocalhost -p"$MYSQL_ROOT_PASSWORD" \
+       < /var/lib/mysql-files/<dump-file>.sql
+   '
+   ```
+
+   Group Replication propagates the imported transactions to the Secondaries automatically; do not run the import on more than one member.
+
+3. **Recreate application users.** A dump that was prepared with the guidance in [How to Import and Export MySQL Data](../../solutions/How_to_Import_and_Export_MySQL_Data.md) does not contain accounts from the source `mysql` system schema. Create application accounts explicitly on the Primary:
+
+   ```sql
+   CREATE USER 'app'@'%' IDENTIFIED BY '<strong-password>';
+   GRANT SELECT, INSERT, UPDATE, DELETE ON <db>.* TO 'app'@'%';
+   ```
+
+4. **Clean up.** Remove the staged dump from `/var/lib/mysql-files/` once the import has been verified.
+
+## When to prefer the operator-managed backup CR
+
+For full-cluster, scheduled, or cross-cluster restores, use the `MysqlBackup` and `MysqlRestore` CRs provided by the operator instead of a manual `mysqldump` flow — those CRs interact with the platform's backup center and S3 storage and are the supported path for production data movement. The manual procedure on this page is intended for ad-hoc business-data migrations and one-off schema imports.

--- a/docs/en/how_to/80-mgr-operations-handbook.mdx
+++ b/docs/en/how_to/80-mgr-operations-handbook.mdx
@@ -1,0 +1,327 @@
+---
+weight: 80
+i18n:
+  title:
+    en: MySQL-MGR Operations Handbook
+    zh: MySQL-MGR 运维手册
+title: MySQL-MGR Operations Handbook
+kind:
+   - Solution
+products:
+  - Alauda Application Services
+productsVersion:
+  - 4.x
+---
+
+# MySQL-MGR Operations Handbook
+
+This handbook collects the architecture, group-replication concepts, and day-to-day operational knowledge needed to keep an MGR cluster healthy on Alauda Application Services for MySQL. It is aimed at operators who already understand vanilla MySQL and need to know how the operator wires Group Replication on top of Kubernetes, and how to intervene when the operator's automatic recovery is not enough.
+
+## Background
+
+### Component topology
+
+Each `Mysql` CR running in MGR mode creates the following workloads in its namespace:
+
+- A **StatefulSet** named `<cluster>` running the MySQL servers. Each Pod has four containers by default:
+  - `mysql` — the MySQL server itself.
+  - `mysql-agent` — the operator-side agent that drives MySQL Shell and reconciles the group.
+  - `exporter` — Prometheus metrics exporter.
+  - `slowsql` — slow-query log shipper.
+- A **Deployment** named `<cluster>-router` running a single `router` container per replica.
+- A set of **PersistentVolumeClaims** (one per StatefulSet ordinal) backing MySQL's data directory; PV lifecycle is managed by the CSI driver in use.
+- **Secrets** holding the root and replication-channel passwords, plus **ConfigMaps** holding rendered `my.cnf` fragments.
+
+The StatefulSet uses anti-affinity so that MGR replicas land on different nodes; `topologyKey` and node-selection knobs on the `Mysql` CR refine this further.
+
+### Group Replication primer
+
+MySQL Group Replication is built on the XCom (Paxos-based) protocol and guarantees state-machine consistency across the replicas. The properties the operator relies on:
+
+- **Closed group** — only group members may send messages to the group; outside traffic is dropped.
+- **Total order** — all XCom messages are globally ordered (totally in single-primary, partially in multi-primary). This is the basis for state-machine equivalence.
+- **Safe delivery** — a message must reach all non-faulty members and be acknowledged by a majority before the upper layer is notified.
+- **View synchrony** — every member delivers messages in the same order before any membership change is committed; a view change is a synchronization point.
+
+For Group Replication to work at all, the workload itself must satisfy:
+
+- All replicated tables use the InnoDB transactional storage engine.
+- Every replicated table has an explicit primary key (or an equivalent NOT NULL unique key).
+- All members can reach each other on the group-communication port in both directions, with reasonably stable latency.
+
+### Member states
+
+| State | Meaning | Counted toward the group |
+| --- | --- | --- |
+| `ONLINE` | Fully functional member — can serve clients. | Yes |
+| `RECOVERING` | Joining the group and replaying state from a donor. | No |
+| `OFFLINE` | Plugin loaded but not part of any group. | No |
+| `ERROR` | Recovery or applier hit an error. | No |
+| `UNREACHABLE` | Local failure detector suspects the member is crashed or partitioned. | No |
+
+### Views and view ID
+
+Group Replication manages membership as a sequence of **views**. A view is the set of members during a period without membership change; any join or leave produces a new view with a new `View ID`. The View ID is `<timestamp-prefix>:<sequence>`:
+
+- The timestamp prefix is fixed at the moment the group is initialized and never changes for the lifetime of that group.
+- The sequence increments on every join or leave.
+
+Inspect from any member:
+
+```sql
+SELECT * FROM performance_schema.replication_group_member_stats\G
+```
+
+### Join flow
+
+When a new member requests to join:
+
+1. The candidate connects to one of the seed members listed in `group_replication_group_seeds` (set by the operator). The seed checks `group_replication_ip_whitelist`; the operator leaves this open by default.
+2. The seed broadcasts a view-change message to every member, including the joiner.
+3. Each member runs the view switch, broadcasts its state, and merges every other member's state into its local membership table.
+4. View change only proves the joiner can receive Paxos messages — it is not yet ready to serve. The joiner enters `RECOVERING` and runs the recovery flow before transitioning to `ONLINE`.
+
+### Recovery flow (donor → joiner)
+
+Distributed recovery has two phases:
+
+- **Learn** — the joiner picks one online member as the *donor*. A standard async-replication channel ships the donor's binary log to the joiner, up to the binlog position that corresponds to the view in which the joiner appears. While this is going on, the joiner *also* caches every Group-Replication transaction it sees on the wire.
+- **Catch-up** — the joiner replays the queued transactions. When the queue drains to zero, it is marked `ONLINE`.
+
+### Leaving the group
+
+Voluntary and involuntary leaves behave differently — this matters for quorum.
+
+- **Voluntary leave** (`STOP GROUP_REPLICATION` from inside the server): triggers a view reconfiguration; the leaver no longer counts toward the group size, and quorum is not reduced. A 5-node group that loses one voluntary leaver becomes a 4-node group.
+- **Involuntary leave** (node crash, network partition, kubelet eviction): the failure detector flags the member `UNREACHABLE`, but the group size does *not* change — the lost member still counts against the quorum threshold. A 5-node group that loses three nodes involuntarily has only two members but still needs three votes for quorum, so writes block until quorum is restored manually.
+
+### MGR limits to be aware of
+
+- **Maximum members per group**: 9. Additional join requests are rejected by the plugin.
+- **InnoDB only**: transactions in non-InnoDB tables are not replicated through GR. The operator's parameter template does not currently block MyISAM at server level, so user-created MyISAM tables can break recovery — see the MyISAM repair runbook.
+- **Explicit primary keys**: required for conflict detection and for efficient relay-log replay. Implicit InnoDB row IDs are not sufficient.
+- **Isolation level**: prefer `READ COMMITTED`. `SERIALIZABLE` is unsupported.
+- **Foreign keys with cascading**: avoid in multi-primary mode. If you cannot remove them, enable `group_replication_enforce_update_everywhere_check` so the plugin rejects writes that would cause silent conflicts.
+
+## Managing the group with MySQL Shell
+
+When the MySQL servers themselves are healthy but Group Replication is wedged, drive the recovery from `mysql-agent`. The MGR Shell helpers live there with the right credentials and tooling pre-installed.
+
+### Open a shell on a member
+
+```bash
+kubectl exec -it -n <namespace> <cluster>-0 -c mysql-agent -- bash
+mysqlsh root@localhost -p"$MYSQL_ROOT_PASSWORD"
+```
+
+The default mode is JavaScript; the `dba` global is the entry point for cluster operations.
+
+### Inspect cluster status
+
+```javascript
+dba.getCluster().status()
+```
+
+Example output:
+
+```json
+{
+  "clusterName": "Cluster",
+  "defaultReplicaSet": {
+    "name": "default",
+    "primary": "mgr-0.mgr:3306",
+    "ssl": "REQUIRED",
+    "status": "OK",
+    "statusText": "Cluster is ONLINE and can tolerate up to ONE failure.",
+    "topology": {
+      "mgr-0.mgr:3306": { "memberRole": "PRIMARY",   "mode": "R/W", "status": "ONLINE" },
+      "mgr-1.mgr:3306": { "memberRole": "SECONDARY", "mode": "R/O", "status": "ONLINE" },
+      "mgr-2.mgr:3306": { "memberRole": "SECONDARY", "mode": "R/O", "status": "ONLINE" }
+    },
+    "topologyMode": "Single-Primary"
+  }
+}
+```
+
+Watch the `status`, `statusText`, and each member's `status` field.
+
+### Rejoin a member to the group
+
+Run on a member with quorum. Use when an instance fell out of the view but its metadata still references it.
+
+```javascript
+dba.getCluster().rejoinInstance("mgr-2.mgr:3306")
+```
+
+### Add a new (or previously removed) instance
+
+```javascript
+dba.getCluster().addInstance("mgr-2.mgr:3306")
+```
+
+### Remove an instance
+
+Typically used on secondaries.
+
+```javascript
+dba.getCluster().removeInstance("mgr-2.mgr:3306")
+```
+
+### Reboot from complete outage
+
+When every member is offline.
+
+```javascript
+dba.rebootClusterFromCompleteOutage()
+```
+
+### Force quorum from a partition
+
+When involuntary leaves dropped the group below quorum and a subset is still alive. The Shell will read the operator log to identify the member with the most complete GTID set — pick *that* member as the partition holder.
+
+:::warning
+`forceQuorumUsingPartitionOf` can cause data loss if the wrong partition is chosen. Confirm the GTID comparison below before running it.
+:::
+
+```javascript
+dba.getCluster().forceQuorumUsingPartitionOf("mgr-0.mgr:3306")
+```
+
+### Drop metadata
+
+If no combination of the above can rejoin the instances, delete the cluster metadata and recreate it.
+
+```javascript
+dba.dropMetadataSchema()
+```
+
+### Re-create the cluster
+
+```javascript
+dba.createCluster("Cluster")
+```
+
+## Common issues and resolutions
+
+Before intervening, collect the operator log, the `mysql-agent` log on each Pod, and the MySQL error log; the steps below assume you have them.
+
+### 1. Donor node crashed mid-recovery; cluster wedged
+
+**Symptoms.** A rolling restart cycled `mysql-1` while `mysql-2` was already its recovery donor. `mysql-2`'s node then went down; `mysql-1` cannot finish recovery; the surviving members cannot reach quorum and the whole cluster is offline.
+
+**Procedure.**
+
+1. From every reachable member, dump the executed-plus-received GTID set:
+
+   ```sql
+   SELECT IFNULL(
+     GTID_SUBTRACT(
+       CONCAT_WS(',',
+         @@global.GTID_EXECUTED,
+         (SELECT GROUP_CONCAT(received_transaction_set)
+            FROM performance_schema.replication_connection_status
+           WHERE channel_name IN ('group_replication_applier'))
+       ),
+     ''),
+   '') AS gtid_set;
+   ```
+
+2. Compare the sets pairwise with `GTID_SUBSET('<set1>', '<set2>')`. A return of `1` means `set1` ⊆ `set2`; the member that is *not* a subset of any other holds the most complete history. Choose that member.
+
+3. Recover from the chosen member.
+
+   - If every member is offline:
+
+     ```bash
+     kubectl exec -it -n <namespace> <cluster>-0 -c mysql-agent -- bash
+     mysqlsh root@localhost -p"$MYSQL_ROOT_PASSWORD"
+     ```
+
+     ```javascript
+     dba.rebootClusterFromCompleteOutage()
+     c = dba.getCluster()
+     c.status()
+     ```
+
+   - If at least one member is still online but quorum is lost:
+
+     ```javascript
+     c = dba.getCluster()
+     c.forceQuorumUsingPartitionOf("<chosen-cluster>-0.<svc>:3306")
+     c.status()
+     ```
+
+### 2. MGR will not become ready after restart
+
+**Symptoms.** The operator log shows `no quorum` for the survivor. Two Pods are `NotReady`, but the third has not actually left the group (so `rebootClusterFromCompleteOutage` refuses to run).
+
+**Resolution.** Force the still-not-offline Pod offline manually so the operator's reboot path can engage.
+
+```bash
+kubectl exec -it -n <namespace> <cluster>-0 -c mysql -- \
+  mysql -uroot -p"$MYSQL_ROOT_PASSWORD" -e 'STOP GROUP_REPLICATION;'
+```
+
+The operator will then run `dba.rebootClusterFromCompleteOutage()` automatically.
+
+### 3. `wait_timeout` change does not take effect
+
+**Symptoms.** `SHOW VARIABLES LIKE 'wait_timeout'` returns the old value even after a parameter-template change and rolling restart.
+
+**Resolution.** MySQL applies one of `wait_timeout` or `interactive_timeout` based on the connection's interactive flag. Set both in the same CR change:
+
+```yaml
+spec:
+  params:
+    mysql:
+      mysqld:
+        wait_timeout: "86400"
+        interactive_timeout: "86400"
+```
+
+### 4. `sysbench prepare` OOM-kills the Pod
+
+**Symptoms.** During `sysbench prepare`, the secondary that is replaying index-creation transactions exceeds its memory limit and is restarted; connections to it break.
+
+**Resolution.** `sysbench prepare` does single-table bulk index writes that are not representative of real workloads. Reduce the relevant memory ceilings:
+
+```yaml
+spec:
+  params:
+    mysql:
+      mysqld:
+        loose-group_replication_message_cache_size: "134217728"   # 128 MiB
+        innodb_online_alter_log_max_size: "33554432"              # 32 MiB
+```
+
+### 5. Router connection cap reached
+
+**Symptoms.** Application errors with `Too many connections` once concurrent load exceeds MySQL's default of 151 or Router's default of 512.
+
+**Resolution.** Raise both:
+
+```yaml
+spec:
+  params:
+    mysql:
+      mysqld:
+        max_connections: "2000"
+    router:
+      DEFAULT:
+        max_total_connections: "2000"
+```
+
+Apply with `kubectl apply -f <cr>.yaml`; the operator rolls the StatefulSet and the Router Deployment.
+
+### 6. Clients fail with `mysql_native_password`
+
+**Symptoms.** Older clients (or driver versions) cannot authenticate because MGR users default to `caching_sha2_password`.
+
+**Resolution.** Create application users with the older plugin instead of changing the cluster default:
+
+```sql
+CREATE USER '<user>'@'<host>' IDENTIFIED WITH mysql_native_password BY '<password>';
+GRANT <privileges> ON <db>.* TO '<user>'@'<host>';
+```
+
+Leave the root and replication users on `caching_sha2_password` — they should not be downgraded.

--- a/docs/en/how_to/85-mgr-operator-operations-guide.mdx
+++ b/docs/en/how_to/85-mgr-operator-operations-guide.mdx
@@ -1,0 +1,217 @@
+---
+weight: 85
+i18n:
+  title:
+    en: MySQL Group Replication Operator Operations Guide
+    zh: MySQL Group Replication Operator 运维手册
+title: MySQL Group Replication Operator Operations Guide
+kind:
+   - Solution
+products:
+  - Alauda Application Services
+productsVersion:
+  - 4.x
+---
+
+# MySQL Group Replication Operator Operations Guide
+
+This guide summarizes the MySQL Group Replication (MGR) architecture and the operational knowledge needed to keep a `Mysql` CR-managed cluster healthy. It covers the consistency model, the membership and recovery flows, the upstream limits MGR imposes on the schema, and recipes for the most common failure modes seen during day-2 operations.
+
+## Background
+
+### Architecture
+
+MGR is an upstream MySQL plugin. Each node runs a complete MySQL Server instance and replicates ROW-format binary logs identified by GTIDs. Three nodes is the default deployment shape; the group can scale up to the limit imposed by upstream (see [MGR limits](#mgr-limits)).
+
+The plugin stack consists of four layers:
+
+1. **APIs layer** — entry point inside MySQL Server.
+2. **Components layer** — captures transaction metadata.
+3. **Replication protocol module** — propagates transactions between members.
+4. **GCS API + Paxos engine** — drives consensus and guarantees that committed transactions are eventually applied on every member.
+
+Applications drive transactions against MySQL Server; the APIs layer hands them to the components layer, the replication protocol ships them to peers, and Paxos guarantees eventual consistency across the group.
+
+A group can run in one of two modes:
+
+- **Single-primary** (operator default) — one writable PRIMARY plus read-only SECONDARY members. The Router transparently routes writes to the PRIMARY.
+- **Multi-primary** — every member accepts writes.
+
+In either mode the data stored on each member is identical: writes performed against one member are propagated to every other member. Nothing is shared; every member keeps its own full, independent copy.
+
+### Member states
+
+| State | Description | Counts toward quorum |
+| --- | --- | --- |
+| `ONLINE` | Fully functional group member; clients can connect and run transactions. | Yes |
+| `RECOVERING` | Member is joining the group and pulling state from a donor. | No |
+| `OFFLINE` | Plugin is loaded but the member is not part of any group. | No |
+| `ERROR` | Recovery or applier failed; the member has dropped out. | No |
+| `UNREACHABLE` | The local failure detector suspects the member has crashed or the network has dropped. | No |
+
+Inspect the live group state from any member:
+
+```sql
+SELECT MEMBER_HOST, MEMBER_PORT, MEMBER_STATE, MEMBER_ROLE
+FROM performance_schema.replication_group_members;
+```
+
+### Views
+
+MGR organizes membership into **group views** identified by a `view_id`. A view spans the time interval during which the membership does not change. Any join or leave triggers a view change and bumps the view id.
+
+The view id has two parts:
+
+- **Timestamp prefix** — stamped when the group is bootstrapped. Constant for the lifetime of the group.
+- **Sequence number** — starts at 1 and increments on every join or leave.
+
+Inspect current group-level statistics:
+
+```sql
+SELECT * FROM performance_schema.replication_group_member_stats\G
+```
+
+### Join flow
+
+When a new member joins:
+
+1. The joiner connects to a member listed in `group_replication_group_seeds` over TCP.
+2. The seed checks the IP allow list (`group_replication_ip_whitelist`). MGR places no restriction by default.
+3. The seed broadcasts a view-change message to every existing member, including the joiner.
+4. Every member emits a state-exchange message; each side updates its local member list.
+5. The joiner runs **distributed recovery** to catch up on data, then transitions to `ONLINE`.
+
+The sequence is **view switch → data sync → Paxos message application → ONLINE**. Reaching the new view does **not** mean the joiner serves traffic — recovery must complete first.
+
+### Distributed recovery
+
+Recovery completes in two phases:
+
+**Phase 1 — Learn**
+
+- The joiner picks an ONLINE donor.
+- Standard asynchronous replication ships the donor's binary log up to the point at which the joiner became part of the view.
+- Concurrently, every transaction broadcast in the group is buffered locally on the joiner.
+
+**Phase 2 — Catch up**
+
+- The joiner drains the buffered queue.
+- When the queue reaches zero, the member is promoted to `ONLINE`.
+
+### Leaving the group
+
+Members can leave voluntarily or involuntarily; the cluster reacts very differently in each case.
+
+**Voluntary leave** — triggered by `STOP GROUP_REPLICATION` or a graceful shutdown:
+
+- The leaver triggers a view change and waits until the majority of members agree on the new configuration before exiting.
+- The group size shrinks; no quorum votes are "lost". A 5-node group becomes a 4-node group and never blocks because of the leave.
+
+**Involuntary leave** — crash, network partition, OS failure:
+
+- The failure detector flags the member; a view-change is broadcast.
+- The expected group size **does not change** — the member is marked `UNREACHABLE` instead of being removed.
+- Quorum is held against the original group size. If too many members leave involuntarily, the remaining ONLINE members lose quorum and the group blocks new writes.
+
+Worked example with a 5-node group:
+
+- One node crashes → 4 ONLINE, 1 UNREACHABLE → group keeps majority and continues serving.
+- Two more nodes crash → 2 ONLINE, 3 UNREACHABLE → no majority → group blocks until an operator intervenes.
+
+### MGR limits
+
+| Limit | Detail |
+| --- | --- |
+| Maximum members | 9 per group. Additional join requests are rejected. Upstream benchmarking established this as a safe upper bound on stable LAN topologies. |
+| Storage engine | Tables must use InnoDB. The optimistic concurrency model and commit-time conflict detection depend on InnoDB internals. System tables like `mysql.user` can remain MyISAM because they almost never change. |
+| Primary key | Every table requires an **explicit** primary key — not the InnoDB rowid. The primary key is used both for conflict detection at commit time and for efficient relay-log apply. |
+| Isolation level | `READ COMMITTED` is recommended. `SERIALIZABLE` is not supported. RC avoids gap locks and pairs well with the distributed conflict detector. |
+| Foreign keys | Cascading foreign keys are discouraged. If a legacy schema with cascades must run in multi-primary mode, set `group_replication_enforce_update_everywhere_check` so cross-member checks are enforced. |
+
+## Troubleshooting
+
+### First cluster member fails to initialize
+
+**Symptom**
+
+A fresh `Mysql` CR is created but the first pod never becomes Ready: the `mysql` container starts, the `mysql-agent` sidecar never reaches Ready, and the bootstrap stalls.
+
+**Cause**
+
+PVCs left behind by a previously-deleted cluster with the **same name** are being re-attached to the new cluster. The on-disk state belongs to a different bootstrap and the agent refuses to initialize over it.
+
+**Resolution**
+
+1. List PVCs in the namespace and look for ones whose names match the new cluster but whose creation timestamps or `volumeName` indicate they belong to a deleted cluster:
+
+   ```bash
+   kubectl -n <namespace> get pvc -l app.kubernetes.io/instance=<cluster>
+   ```
+
+2. Either pick a different cluster name in the new `Mysql` CR, or remove the orphan PVCs and re-create the cluster:
+
+   ```bash
+   kubectl -n <namespace> delete pvc -l app.kubernetes.io/instance=<cluster>
+   ```
+
+   :::warning
+   Deleting PVCs is destructive. Confirm no in-use data lives on those volumes before deletion.
+   :::
+
+### Cluster cannot recover after an OOM kill, even after raising memory
+
+**Symptom**
+
+The `mysql` container is OOM-killed during bootstrap. Memory limits are raised on the `Mysql` CR, but the cluster still cannot come up. The `mysql` and `mysql-agent` logs show password-related authentication failures during initialization.
+
+**Cause**
+
+The MGR bootstrap script populates the root password as part of the first-start initialization. If the container is killed before initialization completes, MySQL ends up with an empty internal password while the operator still treats the configured password as canonical. Every subsequent connection from `mysql-agent` fails authentication.
+
+**Resolution**
+
+There is no in-place fix: the on-disk MySQL state is desynced from the operator's password Secret. Re-create the cluster from scratch with the larger limits set up front.
+
+1. Delete the `Mysql` CR. If you do not need the corrupted data, also delete the associated PVCs.
+2. Re-create the `Mysql` CR with the larger memory limits applied via a pod patch so the new bootstrap completes safely:
+
+   ```yaml
+   spec:
+     mgr:
+       patches:
+         podPatches:
+           mysql:
+             spec:
+               containers:
+                 - name: mysql
+                   resources:
+                     limits:
+                       memory: 8Gi
+                     requests:
+                       memory: 4Gi
+   ```
+
+### A pod is stuck during a rolling update
+
+**Symptom**
+
+During a rolling upgrade or parameter change one of the MGR pods stops responding. The `mysql` container is up but `mysql-agent` cannot connect to it, and the rest of the group still has quorum.
+
+**Resolution**
+
+1. Try to log in to the unresponsive pod's `mysql` container manually:
+
+   ```bash
+   kubectl -n <namespace> exec -it <pod> -c mysql -- \
+     mysql -uroot -p"$MYSQL_PASSWORD" -e "SELECT 1"
+   ```
+
+2. If the connection hangs or times out, delete the pod so the StatefulSet recreates it:
+
+   ```bash
+   kubectl -n <namespace> delete pod <pod>
+   ```
+
+3. Wait for the operator to bring the new pod into the group — first as `RECOVERING`, then as `ONLINE`. The rolling update resumes automatically once the member is healthy.
+
+   If the operator already has aggressive readiness-probe thresholds configured, the kubelet eventually restarts the container on its own and the operator rebuilds membership without manual deletion.

--- a/docs/en/how_to/85-mgr-operator-operations-guide.mdx
+++ b/docs/en/how_to/85-mgr-operator-operations-guide.mdx
@@ -118,6 +118,8 @@ Worked example with a 5-node group:
 - One node crashes → 4 ONLINE, 1 UNREACHABLE → group keeps majority and continues serving.
 - Two more nodes crash → 2 ONLINE, 3 UNREACHABLE → no majority → group blocks until an operator intervenes.
 
+<a id="mgr-limits" />
+
 ### MGR limits
 
 | Limit | Detail |

--- a/docs/en/how_to/85-mgr-operator-operations-guide.mdx
+++ b/docs/en/how_to/85-mgr-operator-operations-guide.mdx
@@ -118,9 +118,7 @@ Worked example with a 5-node group:
 - One node crashes → 4 ONLINE, 1 UNREACHABLE → group keeps majority and continues serving.
 - Two more nodes crash → 2 ONLINE, 3 UNREACHABLE → no majority → group blocks until an operator intervenes.
 
-<a id="mgr-limits" />
-
-### MGR limits
+### MGR limits \{#mgr-limits}
 
 | Limit | Detail |
 | --- | --- |

--- a/docs/en/how_to/90-tune-mysql-router-max-connections.mdx
+++ b/docs/en/how_to/90-tune-mysql-router-max-connections.mdx
@@ -1,0 +1,130 @@
+---
+weight: 90
+i18n:
+  title:
+    en: Raise the MySQL Router Connection Cap
+    zh: 调整 MySQL Router 的最大连接数
+title: Raise the MySQL Router Connection Cap
+kind:
+   - Solution
+products:
+  - Alauda Application Services
+productsVersion:
+  - 4.x
+---
+
+# Raise the MySQL Router Connection Cap
+
+MySQL Router ships with `max_total_connections = 512` and the MySQL server itself defaults to `max_connections = 151`. Workloads that need more concurrent client connections will see `Too many connections` errors well before either of these knobs is intentionally tuned. This page walks through raising the cap on both layers, plus the idle-connection timeouts that typically need raising at the same time.
+
+## Background
+
+Three related knobs control client-connection capacity on an MGR cluster:
+
+- **`max_connections` on the MySQL server** — the per-instance cap; clients connecting through Router are still counted here once the connection is routed to a backend.
+- **`max_total_connections` in Router's `[DEFAULT]` section** — the cap Router applies before opening a backend connection.
+- **`wait_timeout` / `interactive_timeout` on MySQL** — how long an idle client connection is allowed to live before MySQL closes it. If applications keep long-lived idle connections, both of these need raising or the connection budget churns unnecessarily.
+
+In v4.x the canonical place to set all of these is `spec.params.*` on the `Mysql` CR; the operator renders the values into the running `my.cnf` and Router config, then performs a rolling restart.
+
+## Procedure
+
+### 1. Back the cluster up before changing parameters
+
+A rolling restart on a misconfigured CR can leave the cluster wedged. Take a logical dump first.
+
+```bash
+kubectl exec -it -n <namespace> <cluster>-0 -c mysql -- /bin/bash
+```
+
+Inside the Pod:
+
+```bash
+mysqldump \
+  --user=root --host=localhost --password="$MYSQL_ROOT_PASSWORD" \
+  --single-transaction --source-data=1 --set-gtid-purged=AUTO \
+  --triggers -R -E -A \
+  > /var/lib/mysql/$(date +%Y%m%d)_fullbackup.sql
+```
+
+Only `/var/lib/mysql` is writable inside the container. After the dump finishes, copy it off the Pod with `kubectl cp` if you want to keep it outside the PVC.
+
+Also save the current CR for rollback:
+
+```bash
+kubectl get mysql -n <namespace> <cluster> -o yaml > <cluster>-backup.yaml
+```
+
+### 2. Edit the `Mysql` CR
+
+Set the new connection cap on both the MySQL server and Router, and bump the idle-connection timeouts so long-lived clients are not reaped at the old 3600 s default.
+
+```yaml
+apiVersion: mysql.middleware.alauda.io/v1
+kind: Mysql
+metadata:
+  name: <cluster>
+  namespace: <namespace>
+spec:
+  params:
+    mysql:
+      mysqld:
+        max_connections: "2000"
+        wait_timeout: "86400"
+        interactive_timeout: "86400"
+    router:
+      DEFAULT:
+        max_total_connections: "2000"
+```
+
+Apply:
+
+```bash
+kubectl apply -f <cluster>.yaml
+```
+
+:::warning
+The MySQL server's `max_connections` must be at least as large as Router's `max_total_connections`. If Router opens more backend connections than the server allows, clients will see authentication-time failures instead of a clean limit.
+:::
+
+### 3. Watch the rolling restart
+
+The operator restarts the MGR StatefulSet one Pod at a time. Verify each Pod re-joins the group before the next one is cycled:
+
+```bash
+kubectl get pods -n <namespace> -l app.kubernetes.io/instance=<cluster> -w
+kubectl logs -n <namespace> <cluster>-0 -c mysql-agent --tail=200 -f
+```
+
+Once the three MGR Pods are `Ready` again, the operator restarts the Router Deployment:
+
+```bash
+kubectl rollout status -n <namespace> deploy/<cluster>-router
+```
+
+### 4. Verify the new values
+
+On any MGR Pod:
+
+```bash
+kubectl exec -it -n <namespace> <cluster>-0 -c mysql -- \
+  mysql -uroot -p"$MYSQL_ROOT_PASSWORD" -e "SHOW VARIABLES LIKE '%timeout%';"
+```
+
+Confirm `wait_timeout` and `interactive_timeout` both read `86400`, and `max_connections` reads `2000`.
+
+On any Router Pod, confirm the rendered config file picked up the new cap:
+
+```bash
+kubectl exec -it -n <namespace> <cluster>-router-<id> -c router -- \
+  cat /tmp/mysqlrouter/custom.conf
+```
+
+Look for:
+
+```ini
+[DEFAULT]
+max_total_connections = 2000
+```
+
+If the value still reads `512`, check that the change actually landed under `spec.params.router.DEFAULT.*` (the legacy `spec.mgr.router.configuration` block is still accepted but will be ignored if `spec.params.router` is also present).

--- a/docs/en/how_to/95-manage-and-purge-binlogs.mdx
+++ b/docs/en/how_to/95-manage-and-purge-binlogs.mdx
@@ -1,0 +1,131 @@
+---
+weight: 95
+i18n:
+  title:
+    en: Manage and Purge MGR Binary Logs to Reclaim Disk
+    zh: MGR 二进制日志（binlog）的清理与容量回收
+title: Manage and Purge MGR Binary Logs to Reclaim Disk
+kind:
+   - Solution
+products:
+  - Alauda Application Services
+productsVersion:
+  - 4.x
+---
+
+# Manage and Purge MGR Binary Logs to Reclaim Disk
+
+MySQL binary logs grow until they are purged either automatically (via the retention parameter) or manually (via `PURGE BINARY LOGS`). On an MGR cluster the operator leaves retention to your policy, so it is common to discover that the data PVC has filled with binlogs after a capacity-planning miscalculation. This page covers the supported ways to set retention, drop old binlogs, and avoid taking the cluster down while doing it.
+
+## Background
+
+### Recommendations before purging
+
+- Retain at least **7 days** of binary logs whenever possible — Group Replication needs them for distributed recovery, and DBAs need them for point-in-time restore.
+- Do **not** delete binlogs from the past 24 hours; an MGR donor may still be using them to bring up a recovering member.
+- Purging binlogs is a metadata + sequential-delete operation; it does **not** spike disk IOPS for the running workload.
+
+### Retention parameters
+
+MySQL 8.0 exposes two parameters that control automatic purging:
+
+| Parameter | Versions | Default | Notes |
+| --- | --- | --- | --- |
+| `expire_logs_days` | All 8.0; deprecated since 8.0.3 | `0` (≤ 8.0.1 and ≥ 8.0.11); `30` (8.0.2–8.0.4) | Number of days; `0` disables auto-purge. |
+| `binlog_expire_logs_seconds` | Introduced in 8.0.1 | `0` (≤ 8.0.4); `2592000` = 30 days (≥ 8.0.11) | Seconds; if both are set, this one wins and `expire_logs_days` is ignored with a warning. |
+| `binlog_expire_logs_auto_purge` | 8.0+ | `ON` | Must be `ON` for either of the above to take effect. |
+
+Use `binlog_expire_logs_seconds` exclusively on 8.0.1 and later; treat `expire_logs_days` as legacy.
+
+## Procedure
+
+You have three options, ordered from least disruptive to most surgical:
+
+1. Set a runtime retention value with `SET GLOBAL` (resets on Pod restart).
+2. Set a persistent retention value via the `Mysql` CR (survives restarts; preferred for steady-state).
+3. Force-delete older binlogs with `PURGE BINARY LOGS` when you need an immediate reclaim.
+
+### Option 1 — Temporary retention via `SET GLOBAL`
+
+Useful when you need to reclaim space *right now* and a CR change would be too slow. The setting is lost on the next Pod restart.
+
+```bash
+kubectl exec -it -n <namespace> <cluster>-0 -c mysql -- /bin/bash
+mysql -uroot -hlocalhost -p"$MYSQL_ROOT_PASSWORD"
+```
+
+```sql
+SET GLOBAL binlog_expire_logs_seconds = 604800;   -- 7 days
+SET GLOBAL binlog_expire_logs_auto_purge = ON;
+
+SHOW VARIABLES LIKE '%expire_logs%';
+-- +-------------------------------+--------+
+-- | Variable_name                 | Value  |
+-- +-------------------------------+--------+
+-- | binlog_expire_logs_auto_purge | ON     |
+-- | binlog_expire_logs_seconds    | 604800 |
+-- | expire_logs_days              | 0      |
+-- +-------------------------------+--------+
+
+FLUSH LOGS;
+```
+
+The `FLUSH LOGS` (or any other event that rotates the binlog) is what actually triggers MySQL to delete files older than the retention window — the `SET GLOBAL` alone only updates the policy.
+
+Apply the same change on every MGR Pod (`<cluster>-0`, `<cluster>-1`, `<cluster>-2`) — each member maintains its own binlog stream.
+
+The MySQL root password lives in the cluster's Kubernetes Secret:
+
+```bash
+kubectl get secret -n <namespace> <cluster>-secret \
+  -o jsonpath='{.data.MYSQL_ROOT_PASSWORD}' | base64 -d ; echo
+```
+
+### Option 2 — Persistent retention via the `Mysql` CR
+
+Edit the CR so the values survive Pod restarts. The operator will roll the StatefulSet once and apply the values everywhere.
+
+```yaml
+apiVersion: mysql.middleware.alauda.io/v1
+kind: Mysql
+metadata:
+  name: <cluster>
+  namespace: <namespace>
+spec:
+  params:
+    mysql:
+      mysqld:
+        binlog_expire_logs_auto_purge: "ON"
+        binlog_expire_logs_seconds: "604800"
+```
+
+Apply and verify:
+
+```bash
+kubectl apply -f <cluster>.yaml
+kubectl rollout status -n <namespace> sts/<cluster>
+
+kubectl exec -it -n <namespace> <cluster>-0 -c mysql -- \
+  mysql -uroot -p"$MYSQL_ROOT_PASSWORD" -e "SHOW VARIABLES LIKE '%expire_logs%';"
+```
+
+### Option 3 — Force-delete with `PURGE BINARY LOGS`
+
+When the disk is critically full and waiting for the next rotation is not acceptable.
+
+```bash
+kubectl exec -it -n <namespace> <cluster>-0 -c mysql -- /bin/bash
+mysql -uroot -hlocalhost -p"$MYSQL_ROOT_PASSWORD"
+```
+
+```sql
+PURGE BINARY LOGS BEFORE '2026-05-10 00:00:00';
+-- or by file name:
+PURGE BINARY LOGS TO 'binlog.000123';
+```
+
+:::warning
+`PURGE BINARY LOGS` will refuse to delete logs that are still being read by an active replication channel — including an MGR donor that is currently rebuilding a member. Confirm with `SHOW REPLICA STATUS` and `SELECT * FROM performance_schema.replication_connection_status` that no member is mid-recovery before purging, otherwise you may force that member back into full clone.
+:::
+
+After purging, repeat the same command on the other MGR members — purging on one Pod does not propagate.


### PR DESCRIPTION
## Summary

Migrates 11 how-to pages from the internal Confluence MySQL-MGR space (https://confluence.alauda.cn/display/AL/MySQL-MGR) into `docs/en/how_to/`, translated to English and updated against the v4.x operator's `spec.params` surface.

Source pages were evaluated, classified by destination (mgr-docs/how_to vs knowledge/solutions vs skip), and v4.x-validated against a healthy MGR cluster on v4.3.2 before drafting. Five pages with destructive failure-injection procedures (quorum loss, manual rebuild, etc.) are deliberately deferred — they need throwaway-namespace testing before publishing.

### New how_to pages (weights 60–115)

- 60 — Resolve startup failure on VMs without x86-64-v2 support
- 65 — MySQL TLS support and diagnostics
- 70 — Import and export data on an MGR cluster
- 80 — MySQL-MGR operations handbook
- 85 — MySQL Group Replication Operator operations guide
- 90 — Raise the MySQL Router connection cap
- 95 — Manage and purge MGR binary logs
- 100 — Enable MySQL plugins (built-in and custom via init container)
- 105 — Restore MGR across namespaces and clusters
- 110 — Restore specific databases and tables from an MGR backup
- 115 — Repair MyISAM and missing-PK tables on MGR

### Notable revisions vs. source

- Plugin enablement uses `spec.params.mysql.mysqld.plugin_load_add` + `spec.mgr.patches.podPatches` (the canonical v4 paths), not the legacy `spec.configuration` / `spec.paras`.
- MyISAM-repair page reframed: v4.x default parameter template ships `disabled_storage_engines: "MyISAM,..."` AND `sql_generate_invisible_primary_key: "ON"`, so both failure modes are prevented by default. The page is now positioned as "if you have overridden the defaults".
- Version-pinned references collapsed to `4.x`.

## Test plan

- [x] `node_modules/.bin/doom lint docs` — 0 errors, 0 warnings
- [ ] Reviewer: confirm new weights (60..115) fit the intended how_to ordering
- [ ] Reviewer: spot-check `i18n.title.zh` values render correctly in a doom build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new how-to pages for enabling MySQL server plugins on MGR clusters, including built-in and custom shared-library approaches.
  * Added restore guides for cross-namespace and cross-cluster scenarios, plus selective schema/table restoration.
  * Added MGR troubleshooting and recovery guidance for MyISAM/primary-key issues, VM CPU compatibility, and MySQL TLS diagnostics.
  * Added operational and performance guides: manual data import/export, Router max-connection tuning, and safe binary log management.
  * Expanded operations handbooks covering architecture, recovery flows, and day-2 troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->