### PR TITLE
docs: migrate 4 more MGR how-to runbooks from internal Confluence (batch 2)

### DIFF
--- a/docs/en/how_to/120-run-mgr-as-root.mdx
+++ b/docs/en/how_to/120-run-mgr-as-root.mdx
@@ -1,0 +1,83 @@
+---
+weight: 120
+i18n:
+  title:
+    en: Run an MGR Cluster as the Root User
+    zh: 以 Root 用户运行 MGR 集群
+title: Run an MGR Cluster as the Root User
+kind:
+   - Solution
+products:
+  - Alauda Application Services
+productsVersion:
+  - 4.x
+---
+
+# Run an MGR Cluster as the Root User
+
+By default an MGR cluster managed by Alauda Application Services starts its internal MySQL processes as a non-root, unprivileged user. Some integrations — most commonly legacy storage backends that only expose a root-owned mount — require the database process to run as `root`. This page shows how to opt into root execution and the security trade-offs you accept by doing so.
+
+## Background
+
+The operator sets `runAsNonRoot: true` on the `mysql`, `mysql-router`, exporter, and slow-SQL containers, and runs them under a dedicated non-zero UID. When a workload genuinely cannot function without root (for example, a storage driver that mandates a root-owned path), set `spec.mgr.runAsRoot: true` on the `Mysql` CR. The operator then drops the `runAsNonRoot` restriction and starts the containers as UID 0.
+
+:::warning
+Running MySQL as `root` is **not recommended**. It removes a defense-in-depth layer and introduces real risk:
+
+- **Privilege escalation** — a container-escape or local privilege-escalation bug now yields root on the host and, potentially, the cluster.
+- **Excessive privilege** — violates least-privilege and widens the attack surface.
+- **Weaker isolation** — the Linux root account and the MySQL super-user are conflated, eroding account separation.
+- **Auditing and compliance** — operations are harder to attribute per account, and the configuration may breach database account-management policies.
+
+Enable it only when a hard dependency leaves no alternative, and compensate with tighter network policy, PodSecurity exceptions scoped to the single namespace, and close monitoring.
+:::
+
+## Prerequisites
+
+- An MGR cluster on Alauda Application Services v4.x (the `runAsRoot` field has existed since platform v3.14).
+- Permission to edit the `Mysql` CR (or to create it through the Data Services UI in YAML mode).
+
+## Procedure
+
+1. In the Data Services creation form, configure the cluster as usual, then switch to **YAML** mode and set `spec.mgr.runAsRoot` to `true`:
+
+    ```yaml
+    apiVersion: mysql.middleware.alauda.io/v1
+    kind: Mysql
+    metadata:
+      name: <cluster>
+      namespace: <namespace>
+    spec:
+      mgr:
+        runAsRoot: true
+    ```
+
+    For an existing cluster, edit the CR in place and let the operator roll the StatefulSet:
+
+    ```bash
+    kubectl patch mysql <cluster> -n <namespace> --type merge -p '{"spec":{"mgr":{"runAsRoot":true}}}'
+    kubectl rollout status -n <namespace> statefulset/<cluster>-mgr
+    ```
+
+2. On OpenShift / OCP, root execution additionally requires a Security Context Constraint that permits it. Bind an SCC such as `anyuid` (or a custom SCC with `runAsUser: RunAsAny`) to the cluster's ServiceAccount in the target namespace; otherwise the pods stay `Pending` with an SCC admission error. On ACP (PodSecurity Admission) the equivalent is ensuring the namespace is not under a `restricted` PodSecurity level that would block UID 0.
+
+## Verify
+
+Exec into the `mysql` container and confirm the shell runs as root:
+
+```bash
+kubectl exec -it <cluster>-mgr-0 -n <namespace> -c mysql -- id
+```
+
+A successful result reports `uid=0(root) gid=0(root)`, and an interactive shell shows the `#` root prompt:
+
+```bash
+kubectl exec -it <cluster>-mgr-0 -n <namespace> -c mysql -- bash
+```
+
+If the field is not taking effect, confirm the StatefulSet pod template carries `securityContext.runAsNonRoot: false`:
+
+```bash
+kubectl get statefulset <cluster>-mgr -n <namespace> \
+  -o jsonpath='{.spec.template.spec.containers[?(@.name=="mysql")].securityContext}'
+```

--- a/docs/en/how_to/120-run-mgr-as-root.mdx
+++ b/docs/en/how_to/120-run-mgr-as-root.mdx
@@ -56,7 +56,7 @@ Enable it only when a hard dependency leaves no alternative, and compensate with
 
     ```bash
     kubectl patch mysql <cluster> -n <namespace> --type merge -p '{"spec":{"mgr":{"runAsRoot":true}}}'
-    kubectl rollout status -n <namespace> statefulset/<cluster>-mgr
+    kubectl rollout status -n <namespace> statefulset/<cluster>
     ```
 
 2. On OpenShift / OCP, root execution additionally requires a Security Context Constraint that permits it. Bind an SCC such as `anyuid` (or a custom SCC with `runAsUser: RunAsAny`) to the cluster's ServiceAccount in the target namespace; otherwise the pods stay `Pending` with an SCC admission error. On ACP (PodSecurity Admission) the equivalent is ensuring the namespace is not under a `restricted` PodSecurity level that would block UID 0.
@@ -66,18 +66,18 @@ Enable it only when a hard dependency leaves no alternative, and compensate with
 Exec into the `mysql` container and confirm the shell runs as root:
 
 ```bash
-kubectl exec -it <cluster>-mgr-0 -n <namespace> -c mysql -- id
+kubectl exec -it <cluster>-0 -n <namespace> -c mysql -- id
 ```
 
 A successful result reports `uid=0(root) gid=0(root)`, and an interactive shell shows the `#` root prompt:
 
 ```bash
-kubectl exec -it <cluster>-mgr-0 -n <namespace> -c mysql -- bash
+kubectl exec -it <cluster>-0 -n <namespace> -c mysql -- bash
 ```
 
 If the field is not taking effect, confirm the StatefulSet pod template carries `securityContext.runAsNonRoot: false`:
 
 ```bash
-kubectl get statefulset <cluster>-mgr -n <namespace> \
+kubectl get statefulset <cluster> -n <namespace> \
   -o jsonpath='{.spec.template.spec.containers[?(@.name=="mysql")].securityContext}'
 ```

--- a/docs/en/how_to/125-expose-mgr-via-metallb.mdx
+++ b/docs/en/how_to/125-expose-mgr-via-metallb.mdx
@@ -1,0 +1,94 @@
+---
+weight: 125
+i18n:
+  title:
+    en: Expose an MGR Cluster Through MetalLB
+    zh: 通过 MetalLB 暴露 MGR 集群
+title: Expose an MGR Cluster Through MetalLB
+kind:
+   - Solution
+products:
+  - Alauda Application Services
+productsVersion:
+  - 4.x
+---
+
+# Expose an MGR Cluster Through MetalLB
+
+On a bare-metal or on-premises cluster where [MetalLB](https://metallb.universe.tf/) provides `LoadBalancer` services, an MGR cluster can be reached through a stable virtual IP instead of node IPs and NodePorts. This page shows how to switch the MySQL Router read-write and read-only services to `LoadBalancer` type and, optionally, how to suppress the NodePorts that `LoadBalancer` services allocate by default.
+
+## Background
+
+The MySQL Router fronts an MGR cluster with two services: a read-write service (routes to the primary) and a read-only service (routes to the secondaries). By default these are `ClusterIP` (in-cluster) or `NodePort` (external). When MetalLB is installed and has an address pool, setting the service type to `LoadBalancer` makes MetalLB assign each service an external IP from the pool.
+
+## Prerequisites
+
+- An MGR cluster on Alauda Application Services v4.x.
+- MetalLB is installed and configured with at least one `IPAddressPool` that has free addresses (the field has been usable since platform v3.16).
+- Permission to edit the `Mysql` CR.
+
+## Procedure
+
+1. Set the router read-write and read-only services to `LoadBalancer` under `spec.mgr.router`:
+
+    ```yaml
+    apiVersion: mysql.middleware.alauda.io/v1
+    kind: Mysql
+    metadata:
+      name: <cluster>
+      namespace: <namespace>
+    spec:
+      mgr:
+        router:
+          svcRW:
+            type: LoadBalancer
+          svcRO:
+            type: LoadBalancer
+    ```
+
+2. (Optional) A `LoadBalancer` service in Kubernetes allocates a NodePort for each port by default. If you do not want those NodePorts opened, set `allocateLoadBalancerNodePorts: false` on each service through `spec.mgr.patches.servicePatches`:
+
+    ```yaml
+    spec:
+      mgr:
+        router:
+          svcRW:
+            type: LoadBalancer
+          svcRO:
+            type: LoadBalancer
+        patches:
+          servicePatches:
+            read-write:
+              spec:
+                allocateLoadBalancerNodePorts: false
+            read-only:
+              spec:
+                allocateLoadBalancerNodePorts: false
+    ```
+
+3. Apply the change and wait for the operator to reconcile the services:
+
+    ```bash
+    kubectl apply -f mysql.yaml
+    ```
+
+:::info
+On OpenShift / OCP the same `LoadBalancer` type works with MetalLB (the supported load balancer for bare-metal OpenShift). If you instead front the database with an OpenShift `Route`, note that Routes are HTTP(S)-oriented and are not suitable for the MySQL wire protocol — use a `LoadBalancer` service (MetalLB) or a NodePort for TCP database traffic.
+:::
+
+## Verify
+
+Confirm MetalLB has assigned external IPs to both router services:
+
+```bash
+kubectl get svc -n <namespace> -l app.kubernetes.io/instance=<cluster> \
+  -o wide | grep LoadBalancer
+```
+
+Each service should show an address in the `EXTERNAL-IP` column. Connect through the read-write external IP:
+
+```bash
+mysql -h <external-ip> -P 3306 -uroot -p
+```
+
+If `EXTERNAL-IP` stays `<pending>`, MetalLB has no free address in its pool or no pool covers the service — check the MetalLB controller logs and `IPAddressPool` resources.

--- a/docs/en/how_to/125-expose-mgr-via-metallb.mdx
+++ b/docs/en/how_to/125-expose-mgr-via-metallb.mdx
@@ -81,8 +81,8 @@ On OpenShift / OCP the same `LoadBalancer` type works with MetalLB (the supporte
 Confirm MetalLB has assigned external IPs to both router services:
 
 ```bash
-kubectl get svc -n <namespace> -l app.kubernetes.io/instance=<cluster> \
-  -o wide | grep LoadBalancer
+kubectl get svc -n <namespace> \
+  -l v1alpha1.mysql.middleware.alauda.io/cluster=<cluster> -o wide | grep LoadBalancer
 ```
 
 Each service should show an address in the `EXTERNAL-IP` column. Connect through the read-write external IP:

--- a/docs/en/how_to/130-reuse-pvc-and-password-secret.mdx
+++ b/docs/en/how_to/130-reuse-pvc-and-password-secret.mdx
@@ -27,7 +27,11 @@ The operator derives the names of a cluster's stateful resources from the cluste
 Because these names are deterministic, creating a new `Mysql` CR with the **same name** as a previously deleted cluster makes the operator find and reuse the retained PVCs and Secret instead of provisioning empty ones — the new cluster comes up on the original data.
 
 :::warning
-Reuse depends entirely on the retained PVCs and Secret still existing and matching the new cluster name. Confirm they are present before you recreate, and do not change the storage class or volume size in a way that would force new volumes.
+Reuse depends entirely on the retained PVCs still existing and matching the new cluster name. Confirm they are present before you recreate, and do not change the storage class or volume size in a way that would force new volumes.
+:::
+
+:::warning
+You must retain **both** the data PVCs and the original password Secret. The reused data directory still contains the original credentials, so if the recreated cluster comes up with a *new* password Secret, the operator's agent cannot authenticate and fails with `ERROR 1045 (28000): Access denied for user 'root'@'localhost'` — verified on rds-operator v4.3. Deleting the `Mysql` CR directly with `kubectl delete mysql <name>` retains the PVCs but **removes the `mgr-<name>-password` Secret** (it is owned by the CR). Use the Data Services UI delete flow, which retains the PVCs and keeps the password Secret, and recreate by specifying the old instance name so both are reused. If the original Secret is already gone, back up the `mgr-<name>-password` Secret *before* deleting, or recover from a backup instead of by PVC reuse.
 :::
 
 ## Prerequisites
@@ -65,4 +69,7 @@ kubectl exec -it <name>-0 -n <namespace> -c mysql -- \
   mysql -uroot -p -e "SHOW DATABASES;"
 ```
 
-The application schemas from the original cluster should be listed. If the new cluster instead comes up empty, the PVCs were not reused — verify the names matched exactly and that no empty PVCs were pre-created under the new name before the operator reconciled.
+The application schemas from the original cluster should be listed. Two common failure modes:
+
+- The new cluster comes up **empty** — the PVCs were not reused. Verify the names matched exactly and that no empty PVCs were pre-created under the new name before the operator reconciled.
+- A member stays not-ready and the agent logs `Access denied for user 'root'@'localhost'` (`ERROR 1045`) — the data was reused but the password Secret does not match the original credentials baked into that data. Recreate with the retained original Secret (see the warning above).

--- a/docs/en/how_to/130-reuse-pvc-and-password-secret.mdx
+++ b/docs/en/how_to/130-reuse-pvc-and-password-secret.mdx
@@ -21,7 +21,7 @@ When an MGR cluster is deleted without removing its PersistentVolumeClaims, the 
 
 The operator derives the names of a cluster's stateful resources from the cluster name `<name>`:
 
-- Data PVCs: `mgr-<name>-data-<name>-mgr-<ordinal>` (one per member).
+- Data PVCs: `mgr-<name>-data-<name>-<ordinal>` (one per member).
 - Password Secret: `mgr-<name>-password`.
 
 Because these names are deterministic, creating a new `Mysql` CR with the **same name** as a previously deleted cluster makes the operator find and reuse the retained PVCs and Secret instead of provisioning empty ones — the new cluster comes up on the original data.
@@ -61,7 +61,7 @@ Wait for all members to become ready and confirm the original data is present:
 
 ```bash
 kubectl get mysql <name> -n <namespace>
-kubectl exec -it <name>-mgr-0 -n <namespace> -c mysql -- \
+kubectl exec -it <name>-0 -n <namespace> -c mysql -- \
   mysql -uroot -p -e "SHOW DATABASES;"
 ```
 

--- a/docs/en/how_to/130-reuse-pvc-and-password-secret.mdx
+++ b/docs/en/how_to/130-reuse-pvc-and-password-secret.mdx
@@ -1,0 +1,68 @@
+---
+weight: 130
+i18n:
+  title:
+    en: Reuse a Retained PVC and Password Secret for a New MGR Cluster
+    zh: 复用保留的 PVC 与密码 Secret 创建 MGR 集群
+title: Reuse a Retained PVC and Password Secret for a New MGR Cluster
+kind:
+   - Solution
+products:
+  - Alauda Application Services
+productsVersion:
+  - 4.x
+---
+
+# Reuse a Retained PVC and Password Secret for a New MGR Cluster
+
+When an MGR cluster is deleted without removing its PersistentVolumeClaims, the data and the password Secret remain on the cluster. You can bring the data back online by creating a new MGR cluster that reuses those retained resources, rather than restoring from a backup.
+
+## Background
+
+The operator derives the names of a cluster's stateful resources from the cluster name `<name>`:
+
+- Data PVCs: `mgr-<name>-data-<name>-mgr-<ordinal>` (one per member).
+- Password Secret: `mgr-<name>-password`.
+
+Because these names are deterministic, creating a new `Mysql` CR with the **same name** as a previously deleted cluster makes the operator find and reuse the retained PVCs and Secret instead of provisioning empty ones — the new cluster comes up on the original data.
+
+:::warning
+Reuse depends entirely on the retained PVCs and Secret still existing and matching the new cluster name. Confirm they are present before you recreate, and do not change the storage class or volume size in a way that would force new volumes.
+:::
+
+## Prerequisites
+
+- The original cluster was deleted **without** deleting its PVCs (in the Data Services UI, do not select "delete PVC"; the password Secret is retained by default).
+- The retained PVCs and the `mgr-<name>-password` Secret are still present in the namespace.
+- Platform v3.13 or later (v3.16+ additionally lets you set a new root password that differs from the original at recreation time).
+
+## Procedure
+
+1. Confirm the retained resources exist:
+
+    ```bash
+    kubectl get pvc -n <namespace> | grep "mgr-<name>-data"
+    kubectl get secret mgr-<name>-password -n <namespace>
+    ```
+
+2. In the Data Services creation form, create a cluster using the **same name** as the deleted instance. The operator detects the existing PVCs and password Secret and reuses them.
+
+3. To review or fine-tune the result, switch to **YAML** mode, copy the generated manifest to a file, and apply it explicitly:
+
+    ```bash
+    kubectl create -f mgr.yaml
+    ```
+
+   On v3.15 this kubectl apply step was the supported path for reuse; on v3.16 and later the UI flow above reuses the data directly, and you may also set a new root password that differs from the one stored in the retained Secret.
+
+## Verify
+
+Wait for all members to become ready and confirm the original data is present:
+
+```bash
+kubectl get mysql <name> -n <namespace>
+kubectl exec -it <name>-mgr-0 -n <namespace> -c mysql -- \
+  mysql -uroot -p -e "SHOW DATABASES;"
+```
+
+The application schemas from the original cluster should be listed. If the new cluster instead comes up empty, the PVCs were not reused — verify the names matched exactly and that no empty PVCs were pre-created under the new name before the operator reconciled.

--- a/docs/en/how_to/135-restore-from-legacy-incremental-backup.mdx
+++ b/docs/en/how_to/135-restore-from-legacy-incremental-backup.mdx
@@ -1,0 +1,89 @@
+---
+weight: 135
+i18n:
+  title:
+    en: Restore Data from a Legacy Incremental Backup
+    zh: 使用旧版本增量备份恢复数据
+title: Restore Data from a Legacy Incremental Backup
+kind:
+   - Solution
+products:
+  - Alauda Application Services
+productsVersion:
+  - 4.x
+---
+
+# Restore Data from a Legacy Incremental Backup
+
+The MGR backup-and-restore mechanism changed in platform v3.14. An incremental backup taken by a pre-v3.14 cluster cannot be consumed by the current managed restore flow. This page describes how to recover such a legacy incremental backup manually by downloading the backup archive from object storage and replaying its binary logs into a running cluster.
+
+## Background
+
+A legacy incremental backup is stored as a tar archive of MySQL binary logs in the S3/MinIO bucket recorded on the backup resource. Recovery is a manual binlog replay: download and unpack the archive, then feed the binlog files to a target cluster with `mysqlbinlog`, in order, scoped to the business databases you want to recover.
+
+## Prerequisites
+
+- Network access from your workstation to both the MinIO/S3 endpoint that holds the backup and the target MySQL endpoint.
+- The following client tools installed locally:
+  - `mc` — the MinIO client.
+  - The MySQL 8 client package, which includes `mysqlbinlog`.
+  - `tar`.
+  - `kubectl`, with access to the cluster that owns the backup resource.
+
+:::warning
+Replaying binary logs mutates the target database. Recover into a freshly created cluster or a staging instance first, validate the data, and only then cut applications over. Replaying the wrong range or database can corrupt live data.
+:::
+
+## Procedure
+
+### 1. Inspect the backup resource
+
+Read the backup object to find its storage location and credentials reference:
+
+```bash
+kubectl get -n <namespace> mgr-backup <backup-name> -o yaml
+```
+
+Note `spec.storage.s3.endpoint` (the MinIO API address), the bucket, and the object name. The Access Key and Secret Key are in the Secret referenced by the backup's storage configuration.
+
+### 2. Configure MinIO access
+
+Register the MinIO host with `mc`, using the endpoint from the previous step:
+
+```bash
+mc config host add minio <minio-api-endpoint>
+```
+
+Enter the Access Key and Secret Key when prompted (read them from the configured Secret).
+
+### 3. Download and unpack the archive
+
+Using the bucket and object name from step 1 — for example bucket `mgr` and object `mgr-<cluster>-incr-backup-<timestamp>.tar.gz`, addressed as `minio/mgr/mgr-<cluster>-incr-backup-<timestamp>.tar.gz`:
+
+```bash
+mc cp minio/mgr/mgr-<cluster>-incr-backup-<timestamp>.tar.gz ./
+tar -xf ./mgr-<cluster>-incr-backup-<timestamp>.tar.gz
+```
+
+This produces the binary log files (for example `bin.000003`) in the current directory.
+
+### 4. Replay the binary logs
+
+Replay the binlogs in order with `mysqlbinlog`, scoping each run to one business database with `-d`. Pipe the output into the target cluster's primary. Repeat for each database you need to recover:
+
+```bash
+mysqlbinlog --no-defaults -d <database> bin.000003 \
+  | mysql -h <primary-host> -P <port> -u root -p
+```
+
+For a precise recovery point, bound the replay with `--start-position`/`--stop-position` (or `--start-datetime`/`--stop-datetime`), and apply the binlog files in ascending sequence so transactions are replayed in their original order.
+
+## Verify
+
+Connect to the target and confirm the recovered data is present and consistent:
+
+```bash
+mysql -h <primary-host> -P <port> -u root -p -e "USE <database>; SHOW TABLES; SELECT COUNT(*) FROM <table>;"
+```
+
+Group Replication propagates the replayed transactions from the primary to the secondaries automatically. If rows are missing, confirm you replayed every binlog file in sequence and that the `-d` filter matched the intended database name.


### PR DESCRIPTION
## Summary

Second batch of the MGR knowledge-base consolidation (MIDDLEWARE-31526, MySQL portion). Migrates 4 more historical solution playbooks from the internal Confluence KB into `docs/en/how_to/`:

| New page | Source topic |
|---|---|
| `120-run-mgr-as-root.mdx` | Run the cluster as the root user (`spec.mgr.runAsRoot`) |
| `125-expose-mgr-via-metallb.mdx` | Expose the router via MetalLB / `LoadBalancer` services |
| `130-reuse-pvc-and-password-secret.mdx` | Recreate a cluster reusing retained PVCs + password Secret |
| `135-restore-from-legacy-incremental-backup.mdx` | Manually restore a pre-v3.14 incremental backup (mc + mysqlbinlog) |

## Notes

- Each page is modernized to the v4.x `Mysql` CR (`spec.mgr.*`) and validated against the current operator CRD — `runAsRoot`, `router.svcRW/svcRO`, `patches.servicePatches`, and the `mgr-backup` short name all confirmed present.
- Internal credentials and IPs from the original wiki pages were scrubbed and replaced with placeholders.
- OCP-parity notes added where relevant (SCC for root execution; MetalLB vs. Routes for TCP traffic).
- Lint clean against doom 1.22.1 (the version CI's fresh install resolves `^1.12.1` to); local build clean.

This continues the migration started in #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guide for running MGR clusters as the root user with platform-specific requirements.
  * Added guide for exposing MGR clusters via MetalLB LoadBalancer services.
  * Added guide for reusing persistent storage and secrets when recreating clusters.
  * Added guide for manually restoring legacy incremental backups from object storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->