### PR TITLE
docs(upgrade): scope upgrade page to v4.4.0 with plugin dependencies and Important Notes

### DIFF
--- a/docs/en/installation.mdx
+++ b/docs/en/installation.mdx
@@ -31,7 +31,7 @@ Alauda Container Platform Data Services Essentials (also referred to as **Applic
 ## Installing Alauda Container Platform Data Services RDS Framework
 
 ::: tip Required for v4.4.0
-Alauda Container Platform Data Services RDS Framework is the base operator framework that Alauda Database Service for MySQL extends, and is required. For the v4.4.0 release, install or upgrade it to **v4.3.x** before installing the MySQL operator. See [Upgrade to v4.4.0](./upgrade) for the full plugin dependency list.
+Alauda Container Platform Data Services RDS Framework (the `rds-operator` multi-database base operator) is the base operator framework that Alauda Database Service for MySQL extends, and is required. For the v4.4.0 release, install or upgrade it to **v4.3.0 or higher** before installing the MySQL operator. See [Upgrade to v4.4.0](./upgrade) for the full plugin dependency list.
 :::
 
 ### Prerequisites

--- a/docs/en/installation.mdx
+++ b/docs/en/installation.mdx
@@ -9,8 +9,8 @@ title: Install
 
 ## Installing Alauda Container Platform Data Services Essentials
 
-::: tip Optional Installation
-The plugin serves as a foundational component for Alauda Data Services web console. It is not necessary to install it if the **web console** <span/> is not required.
+::: tip Required for v4.4.0
+Alauda Container Platform Data Services Essentials (also referred to as **Application Services Core**) is a foundational platform component required by Alauda Database Service for MySQL. For the v4.4.0 release, install or upgrade it to **v4.4.0 or higher** before installing the MySQL operator. It also provides the Alauda Data Services web console. See [Upgrade to v4.4.0](./upgrade) for the full plugin dependency list.
 :::
 
 ### Prerequisites

--- a/docs/en/installation.mdx
+++ b/docs/en/installation.mdx
@@ -30,8 +30,8 @@ Alauda Container Platform Data Services Essentials (also referred to as **Applic
 
 ## Installing Alauda Container Platform Data Services RDS Framework
 
-::: tip Optional Installation
-The plugin serves as a foundational component for Alauda Data Services web console. It is not necessary to install it if the web console is not required.
+::: tip Required for v4.4.0
+Alauda Container Platform Data Services RDS Framework is the base operator framework that Alauda Database Service for MySQL extends, and is required. For the v4.4.0 release, install or upgrade it to **v4.3.x** before installing the MySQL operator. See [Upgrade to v4.4.0](./upgrade) for the full plugin dependency list.
 :::
 
 ### Prerequisites

--- a/docs/en/upgrade.mdx
+++ b/docs/en/upgrade.mdx
@@ -7,7 +7,9 @@ sourceSHA: bad20dc1bccc211b5099b8eae64137f02edafcac310c7a753780773b0f75da9a
 title: Upgrade
 ---
 
-# Upgrade
+# Upgrade to v4.4.0
+
+This page describes how to upgrade Alauda Database Service for MySQL (MySQL-MGR) to **v4.4.0**, including the plugin dependencies and prerequisites specific to this release. For patch-version (z-stream) upgrades within a minor version, see [Patch Version Upgrade](./how_to/30-upgrade).
 
 :::warning
 PXC Removal in Alauda Database Service for MySQL v4.3.0
@@ -22,17 +24,17 @@ Alauda Database Service for MySQL-MGR will execute upgrades based on the configu
 
 ## Prerequisites
 
-Before initiating an upgrade, ensure the following:
+Before initiating the upgrade to v4.4.0, ensure the following:
 
-1. **Plugin dependencies are upgraded first**: Alauda Database Service for MySQL builds on foundational Alauda platform and Data Services plugins. Upgrade them to a compatible version **before** upgrading the MySQL operator or rolling instances.
-2. **Version compatibility**: Your current version falls within a supported upgrade path. Review the [Release Notes](./release_notes) for the target version's new features and known issues, and the OperatorHub **Upgrade** prompt for the component and plugin version changes that the upgrade applies.
+1. **Plugin dependencies are upgraded first**: Alauda Database Service for MySQL builds on foundational Alauda platform and Data Services plugins. Upgrade them to a v4.4.0-compatible version **before** upgrading the MySQL operator or rolling instances.
+2. **Version compatibility**: Your current version falls within a supported upgrade path to v4.4.0. Review the [Release Notes](./release_notes) for v4.4.0's new features and known issues, and the OperatorHub **Upgrade** prompt for the component and plugin version changes that the upgrade applies.
 3. **Component health**: All MySQL-MGR instances are in a `Running` (Ready) state before starting the upgrade.
 4. **Resource availability**: The cluster has sufficient CPU, memory, and storage headroom to perform the rolling upgrade.
 5. **PXC migration (if applicable)**: If the platform has any MySQL-PXC instances, complete the [MySQL-PXC Pre-Upgrade Checklist](#mysql-pxc-pre-upgrade-checklist) before upgrading to MySQL Operator v4.3.0 or later.
 
 ### Plugin Dependencies \{#plugin-dependencies}
 
-Like other Alauda Container Platform Data Services plugins, MySQL-MGR depends on the shared Data Services base plugins. Upgrade them in the following order:
+Like other Alauda Container Platform Data Services plugins, MySQL-MGR depends on the shared Data Services base plugins. For the v4.4.0 upgrade, upgrade them to the following minimum versions, in order:
 
 | Order | Plugin | Role | Minimum Version |
 |-------|--------|------|-----------------|

--- a/docs/en/upgrade.mdx
+++ b/docs/en/upgrade.mdx
@@ -38,10 +38,10 @@ Like other Alauda Container Platform Data Services plugins, MySQL-MGR depends on
 
 | Order | Plugin | Role | Minimum Version |
 |-------|--------|------|-----------------|
-| 1 | **Alauda Container Platform Data Services Essentials** (also referred to as Application Services Core) | Foundational platform component that the Data Services plugins and operators build on. | **v4.4.0 or higher** |
-| 2 | **Alauda Container Platform Data Services RDS Framework** (`rds-operator`) | The rds-operator multi-database base operator that the MySQL operator extends. | **v4.3.0 or higher** |
-| 3 | **Alauda Database Service for MySQL** | The MySQL-MGR operator and its instances. | **v4.4.0 or higher** |
-| 4 | **Query Analytics Operator** (`query-analytics-operator`) | Optional companion operator that powers slow query logging and query analysis. Only required if query analytics features are used. | **v4.4.0 or higher** |
+| 1 | **Alauda Container Platform Data Services Essentials** (also referred to as Application Services Core) | Foundational platform component that the Data Services plugins and operators build on. | **v4.4.0** |
+| 2 | **Alauda Container Platform Data Services RDS Framework** (`rds-operator`) | The rds-operator multi-database base operator that the MySQL operator extends. | **v4.3.0** |
+| 3 | **Alauda Database Service for MySQL** | The MySQL-MGR operator and its instances. | **v4.4.0** |
+| 4 | **Query Analytics Operator** (`query-analytics-operator`) | Optional companion operator that powers slow query logging and query analysis. Only required if query analytics features are used. | **v4.4.0** |
 
 :::warning Upgrade the base plugins first
 Always upgrade the **Data Services RDS Framework** (`rds-operator`) to **v4.3.0 or higher** **before** upgrading the MySQL operator or rolling instances. Upgrading the MySQL operator against an older rds-operator can leave instances in an inconsistent or unmanaged state. The OperatorHub **Upgrade** prompt lists the component and plugin version changes for the target release; see the [Install guide](./installation) for the plugin installation steps.

--- a/docs/en/upgrade.mdx
+++ b/docs/en/upgrade.mdx
@@ -20,7 +20,38 @@ Alauda Database Service for MySQL-MGR will execute upgrades based on the configu
 - **Automatic** : Auto-upgrades are triggered immediately upon detecting new component versions.
 - **Manual** : Requires manual approval before initiating the upgrade process.
 
-## MySQL-PXC Pre-Upgrade Checklist
+## Prerequisites
+
+Before initiating an upgrade, ensure the following:
+
+1. **Plugin dependencies are upgraded first**: Alauda Database Service for MySQL builds on foundational Alauda platform and Data Services plugins. Upgrade them to a compatible version **before** upgrading the MySQL operator or rolling instances.
+2. **Version compatibility**: Your current version falls within a supported upgrade path. Review the [Release Notes](./release_notes) for the target version's new features and known issues, and the OperatorHub **Upgrade** prompt for the component and plugin version changes that the upgrade applies.
+3. **Component health**: All MySQL-MGR instances are in a `Running` (Ready) state before starting the upgrade.
+4. **Resource availability**: The cluster has sufficient CPU, memory, and storage headroom to perform the rolling upgrade.
+5. **PXC migration (if applicable)**: If the platform has any MySQL-PXC instances, complete the [MySQL-PXC Pre-Upgrade Checklist](#mysql-pxc-pre-upgrade-checklist) before upgrading to MySQL Operator v4.3.0 or later.
+
+### Plugin Dependencies \{#plugin-dependencies}
+
+Like other Alauda Container Platform Data Services plugins, MySQL-MGR depends on the shared Data Services base plugins. Upgrade them in the following order:
+
+| Order | Plugin | Role | Minimum Version |
+|-------|--------|------|-----------------|
+| 1 | **Alauda Container Platform Data Services Essentials** (also referred to as Application Services Core) | Foundational platform component that the Data Services plugins and operators build on. | **v4.4.0 or higher** |
+| 2 | **Alauda Container Platform Data Services RDS Framework** | Base operator framework that the MySQL operator extends. | **v4.3.x** |
+| 3 | **Alauda Database Service for MySQL** | The MySQL-MGR operator and its instances. | Target upgrade version |
+
+:::warning Upgrade the base plugins first
+Always upgrade the **Data Services RDS Framework** to **v4.3.x** **before** upgrading the MySQL operator or rolling instances. Upgrading the MySQL operator against an older RDS Framework can leave instances in an inconsistent or unmanaged state. The OperatorHub **Upgrade** prompt lists the component and plugin version changes for the target release; see the [Install guide](./installation) for the plugin installation steps.
+:::
+
+### Important Notes
+
+- **Data Services Essentials version**: Upgrading the MySQL operator requires **Alauda Container Platform Data Services Essentials (Application Services Core) v4.4.0 or higher**. Upgrade this foundational platform component to a compatible version **before** upgrading the operator.
+- **Upgrade the base plugins first**: The MySQL operator depends on the Alauda Container Platform Data Services RDS Framework. Upgrade the RDS Framework to **v4.3.x** **before** upgrading the operator. See [Plugin Dependencies](#plugin-dependencies).
+- **MySQL-PXC removal is irreversible**: Starting from MySQL Operator v4.3.0, MySQL-PXC is removed. PXC instances become **unmanaged** immediately after the operator upgrade and cannot be re-managed. Migrate any PXC instances to MySQL-MGR **before** upgrading to v4.3.0 or later — see the [MySQL-PXC Pre-Upgrade Checklist](#mysql-pxc-pre-upgrade-checklist).
+- **Operator rollback is not supported**: Once upgraded, the MySQL operator **cannot be rolled back** to a previous version. Take a verified full backup of every instance before starting the upgrade. See [Rollback considerations](#rollback-considerations).
+
+## MySQL-PXC Pre-Upgrade Checklist \{#mysql-pxc-pre-upgrade-checklist}
 
 If your platform has **MySQL-PXC** instances, complete the following **before upgrading to MySQL Operator v4.3.0 or later**:
 
@@ -175,7 +206,7 @@ If migration cannot be completed within the maintenance window:
 Deleting a PXC custom resource will delete all associated pods and data. Always verify data integrity on the target MGR instance before decommissioning the source PXC instance.
 :::
 
-### Rollback considerations
+### Rollback considerations \{#rollback-considerations}
 
 The MySQL operator **cannot be rolled back** to a previous version after upgrade. If a critical issue occurs:
 

--- a/docs/en/upgrade.mdx
+++ b/docs/en/upgrade.mdx
@@ -39,18 +39,18 @@ Like other Alauda Container Platform Data Services plugins, MySQL-MGR depends on
 | Order | Plugin | Role | Minimum Version |
 |-------|--------|------|-----------------|
 | 1 | **Alauda Container Platform Data Services Essentials** (also referred to as Application Services Core) | Foundational platform component that the Data Services plugins and operators build on. | **v4.4.0 or higher** |
-| 2 | **Alauda Container Platform Data Services RDS Framework** | Base operator framework that the MySQL operator extends. | **v4.3.x** |
+| 2 | **Alauda Container Platform Data Services RDS Framework** (`rds-operator`) | The rds-operator multi-database base operator that the MySQL operator extends. | **v4.3.0 or higher** |
 | 3 | **Alauda Database Service for MySQL** | The MySQL-MGR operator and its instances. | **v4.4.0 or higher** |
 | 4 | **Query Analytics Operator** (`query-analytics-operator`) | Optional companion operator that powers slow query logging and query analysis. Only required if query analytics features are used. | **v4.4.0 or higher** |
 
 :::warning Upgrade the base plugins first
-Always upgrade the **Data Services RDS Framework** to **v4.3.x** **before** upgrading the MySQL operator or rolling instances. Upgrading the MySQL operator against an older RDS Framework can leave instances in an inconsistent or unmanaged state. The OperatorHub **Upgrade** prompt lists the component and plugin version changes for the target release; see the [Install guide](./installation) for the plugin installation steps.
+Always upgrade the **Data Services RDS Framework** (`rds-operator`) to **v4.3.0 or higher** **before** upgrading the MySQL operator or rolling instances. Upgrading the MySQL operator against an older rds-operator can leave instances in an inconsistent or unmanaged state. The OperatorHub **Upgrade** prompt lists the component and plugin version changes for the target release; see the [Install guide](./installation) for the plugin installation steps.
 :::
 
 ### Important Notes
 
 - **Data Services Essentials version**: Upgrading the MySQL operator requires **Alauda Container Platform Data Services Essentials (Application Services Core) v4.4.0 or higher**. Upgrade this foundational platform component to a compatible version **before** upgrading the operator.
-- **Upgrade the base plugins first**: The MySQL operator depends on the Alauda Container Platform Data Services RDS Framework. Upgrade the RDS Framework to **v4.3.x** **before** upgrading the operator. See [Plugin Dependencies](#plugin-dependencies).
+- **Upgrade the base plugins first**: The MySQL operator depends on the Alauda Container Platform Data Services RDS Framework (`rds-operator`). Upgrade the rds-operator to **v4.3.0 or higher** **before** upgrading the operator. See [Plugin Dependencies](#plugin-dependencies).
 - **Query Analytics operator version**: If you use query analytics features (slow query logging and query analysis), upgrade the **Query Analytics Operator (`query-analytics-operator`) to v4.4.0 or higher**. This operator is optional — MySQL-MGR instances function normally without it.
 - **MySQL-PXC removal is irreversible**: Starting from MySQL Operator v4.3.0, MySQL-PXC is removed. PXC instances become **unmanaged** immediately after the operator upgrade and cannot be re-managed. Migrate any PXC instances to MySQL-MGR **before** upgrading to v4.3.0 or later — see the [MySQL-PXC Pre-Upgrade Checklist](#mysql-pxc-pre-upgrade-checklist).
 - **Operator rollback is not supported**: Once upgraded, the MySQL operator **cannot be rolled back** to a previous version. Take a verified full backup of every instance before starting the upgrade. See [Rollback considerations](#rollback-considerations).

--- a/docs/en/upgrade.mdx
+++ b/docs/en/upgrade.mdx
@@ -38,7 +38,7 @@ Like other Alauda Container Platform Data Services plugins, MySQL-MGR depends on
 |-------|--------|------|-----------------|
 | 1 | **Alauda Container Platform Data Services Essentials** (also referred to as Application Services Core) | Foundational platform component that the Data Services plugins and operators build on. | **v4.4.0 or higher** |
 | 2 | **Alauda Container Platform Data Services RDS Framework** | Base operator framework that the MySQL operator extends. | **v4.3.x** |
-| 3 | **Alauda Database Service for MySQL** | The MySQL-MGR operator and its instances. | Target upgrade version |
+| 3 | **Alauda Database Service for MySQL** | The MySQL-MGR operator and its instances. | **v4.4.0 or higher** |
 | 4 | **Query Analytics Operator** (`query-analytics-operator`) | Optional companion operator that powers slow query logging and query analysis. Only required if query analytics features are used. | **v4.4.0 or higher** |
 
 :::warning Upgrade the base plugins first

--- a/docs/en/upgrade.mdx
+++ b/docs/en/upgrade.mdx
@@ -39,6 +39,7 @@ Like other Alauda Container Platform Data Services plugins, MySQL-MGR depends on
 | 1 | **Alauda Container Platform Data Services Essentials** (also referred to as Application Services Core) | Foundational platform component that the Data Services plugins and operators build on. | **v4.4.0 or higher** |
 | 2 | **Alauda Container Platform Data Services RDS Framework** | Base operator framework that the MySQL operator extends. | **v4.3.x** |
 | 3 | **Alauda Database Service for MySQL** | The MySQL-MGR operator and its instances. | Target upgrade version |
+| 4 | **Query Analytics Operator** (`query-analytics-operator`) | Optional companion operator that powers slow query logging and query analysis. Only required if query analytics features are used. | **v4.4.0 or higher** |
 
 :::warning Upgrade the base plugins first
 Always upgrade the **Data Services RDS Framework** to **v4.3.x** **before** upgrading the MySQL operator or rolling instances. Upgrading the MySQL operator against an older RDS Framework can leave instances in an inconsistent or unmanaged state. The OperatorHub **Upgrade** prompt lists the component and plugin version changes for the target release; see the [Install guide](./installation) for the plugin installation steps.
@@ -48,6 +49,7 @@ Always upgrade the **Data Services RDS Framework** to **v4.3.x** **before** upgr
 
 - **Data Services Essentials version**: Upgrading the MySQL operator requires **Alauda Container Platform Data Services Essentials (Application Services Core) v4.4.0 or higher**. Upgrade this foundational platform component to a compatible version **before** upgrading the operator.
 - **Upgrade the base plugins first**: The MySQL operator depends on the Alauda Container Platform Data Services RDS Framework. Upgrade the RDS Framework to **v4.3.x** **before** upgrading the operator. See [Plugin Dependencies](#plugin-dependencies).
+- **Query Analytics operator version**: If you use query analytics features (slow query logging and query analysis), upgrade the **Query Analytics Operator (`query-analytics-operator`) to v4.4.0 or higher**. This operator is optional — MySQL-MGR instances function normally without it.
 - **MySQL-PXC removal is irreversible**: Starting from MySQL Operator v4.3.0, MySQL-PXC is removed. PXC instances become **unmanaged** immediately after the operator upgrade and cannot be re-managed. Migrate any PXC instances to MySQL-MGR **before** upgrading to v4.3.0 or later — see the [MySQL-PXC Pre-Upgrade Checklist](#mysql-pxc-pre-upgrade-checklist).
 - **Operator rollback is not supported**: Once upgraded, the MySQL operator **cannot be rolled back** to a previous version. Take a verified full backup of every instance before starting the upgrade. See [Rollback considerations](#rollback-considerations).
 


### PR DESCRIPTION
## What

The page is now scoped explicitly to the **v4.4.0** upgrade (retitled "Upgrade to v4.4.0", with a link to the patch-version upgrade guide for z-stream upgrades).

The operator-level **Upgrade** page (`docs/en/upgrade.mdx`) previously dove straight into the MySQL-PXC migration checklist and never stated the foundational plugin dependencies — unlike the [Kafka upgrade doc](https://docs.alauda.io/kafka/4.3/upgrade.html), which leads with Prerequisites and a plugin/RDS-Framework requirement.

This adds a **Prerequisites** section before the PXC checklist:

- **Plugin Dependencies** table with the required upgrade order and minimum versions:
  | Order | Plugin | Minimum Version |
  |---|---|---|
  | 1 | Data Services Essentials (a.k.a. Application Services Core) | **v4.4.0+** |
  | 2 | Data Services RDS Framework | **v4.3.x** |
  | 3 | Alauda Database Service for MySQL | **v4.4.0+** |
  | 4 | Query Analytics Operator (`query-analytics-operator`, optional) | **v4.4.0+** |
- **Important Notes**: upgrade base plugins first, Query Analytics operator version (when used), MySQL-PXC removal is irreversible, operator rollback is not supported.
- Version/component deltas point to the OperatorHub **Upgrade** prompt (the Release Notes carry no compatibility matrix).

## Notes

- The base-plugin version requirements (Essentials >= v4.4.0, RDS Framework v4.3.x, Query Analytics >= v4.4.0) are product requirements; there is currently no compatibility matrix page in the docs to cite. If a matrix is added later, these can link to it.
- Query Analytics is an optional companion (slow query logging / analysis); MySQL-MGR functions normally without it.
- In-page-link targets use explicit `\{#id}` anchors (doom 1.22.x auto-slug does not reliably match).
- Lint clean on doom 1.12.1 and 1.22.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the upgrade guide for **v4.4.0** with a clearer title/intro, a new **Prerequisites** section (pre-checklist, plugin dependency minimum versions, and required upgrade order), plus warnings including **MySQL-PXC removal** and other important upgrade constraints.
  * Improved navigation in the upgrade guide by adding an explicit **rollback** anchor.
  * Revised installation guidance to mark **Data Services Essentials (v4.4.0+)** and **Data Services RDS Framework (v4.3.0+)** as required prerequisites before installing the MySQL operator, with a link to full dependency details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->