### PR TITLE
docs(upgrade): add v4.4.0 plugin dependencies and Important Notes

### DIFF
--- a/docs/en/installation.mdx
+++ b/docs/en/installation.mdx
@@ -31,7 +31,7 @@ Alauda Container Platform Data Services Essentials (also referred to as **Applic
 ## Installing Alauda Container Platform Data Services RDS Framework
 
 ::: tip Required for v4.4.0
-Alauda Container Platform Data Services RDS Framework is the base operator framework that Alauda Database Service for MySQL extends, and is required. For the v4.4.0 release, install or upgrade it to **v4.3.x** before installing the MySQL operator. See [Upgrade to v4.4.0](./upgrade) for the full plugin dependency list.
+Alauda Container Platform Data Services RDS Framework (the `rds-operator` multi-database base operator) is the base operator framework that Alauda Database Service for MySQL extends, and is required. For the v4.4.0 release, install or upgrade it to **v4.3.0 or higher** before installing the MySQL operator. See [Upgrade to v4.4.0](./upgrade) for the full plugin dependency list.
 :::
 
 ### Prerequisites

--- a/docs/en/installation.mdx
+++ b/docs/en/installation.mdx
@@ -9,8 +9,8 @@ title: Install
 
 ## Installing Alauda Container Platform Data Services Essentials
 
-::: tip Optional Installation
-The plugin serves as a foundational component for Alauda Data Services web console. It is not necessary to install it if the **web console** <span/> is not required.
+::: tip Required for v4.4.0
+Alauda Container Platform Data Services Essentials (also referred to as **Application Services Core**) is a foundational platform component required by Alauda Database Service for MySQL. For the v4.4.0 release, install or upgrade it to **v4.4.0 or higher** before installing the MySQL operator. It also provides the Alauda Data Services web console. See [Upgrade to v4.4.0](./upgrade) for the full plugin dependency list.
 :::
 
 ### Prerequisites

--- a/docs/en/installation.mdx
+++ b/docs/en/installation.mdx
@@ -30,8 +30,8 @@ Alauda Container Platform Data Services Essentials (also referred to as **Applic
 
 ## Installing Alauda Container Platform Data Services RDS Framework
 
-::: tip Optional Installation
-The plugin serves as a foundational component for Alauda Data Services web console. It is not necessary to install it if the web console is not required.
+::: tip Required for v4.4.0
+Alauda Container Platform Data Services RDS Framework is the base operator framework that Alauda Database Service for MySQL extends, and is required. For the v4.4.0 release, install or upgrade it to **v4.3.x** before installing the MySQL operator. See [Upgrade to v4.4.0](./upgrade) for the full plugin dependency list.
 :::
 
 ### Prerequisites

--- a/docs/en/upgrade.mdx
+++ b/docs/en/upgrade.mdx
@@ -8,7 +8,7 @@ sourceSHA: bad20dc1bccc211b5099b8eae64137f02edafcac310c7a753780773b0f75da9a
 title: Upgrade
 ---
 
-# Upgrade
+# Upgrade to v4.4.0
 
 :::warning
 PXC Removal in Alauda Database Service for MySQL v4.3.0
@@ -27,6 +27,39 @@ There are three kinds of upgrade for MySQL-MGR:
 - **MySQL major version upgrade (8.0 → 8.4)** — upgrade an existing 8.0 cluster in place to 8.4. See below.
 - **MySQL-PXC to MySQL-MGR migration** — required before upgrading the operator to v4.3.0 or later if you still run PXC instances. See the checklist below and [Migrate MySQL-PXC to MySQL-MGR](./how_to/35-migrate-from-pxc).
 
+## Prerequisites
+
+Before initiating the upgrade to v4.4.0, ensure the following:
+
+1. **Plugin dependencies are upgraded first**: Alauda Database Service for MySQL builds on foundational Alauda platform and Data Services plugins. Upgrade them to a v4.4.0-compatible version **before** upgrading the MySQL operator or rolling instances.
+2. **Version compatibility**: Your current version falls within a supported upgrade path to v4.4.0. Review the [Release Notes](./release_notes) for v4.4.0's new features and known issues, and the OperatorHub **Upgrade** prompt for the component and plugin version changes that the upgrade applies.
+3. **Component health**: All MySQL-MGR instances are in a `Running` (Ready) state before starting the upgrade.
+4. **Resource availability**: The cluster has sufficient CPU, memory, and storage headroom to perform the rolling upgrade.
+5. **PXC migration (if applicable)**: If the platform has any MySQL-PXC instances, complete the [MySQL-PXC Pre-Upgrade Checklist](#mysql-pxc-pre-upgrade-checklist) before upgrading to MySQL Operator v4.3.0 or later.
+
+### Plugin Dependencies \{#plugin-dependencies}
+
+Like other Alauda Container Platform Data Services plugins, MySQL-MGR depends on the shared Data Services base plugins. For the v4.4.0 upgrade, upgrade them to the following minimum versions, in order:
+
+| Order | Plugin | Role | Minimum Version |
+|-------|--------|------|-----------------|
+| 1 | **Alauda Container Platform Data Services Essentials** (also referred to as Application Services Core) | Foundational platform component that the Data Services plugins and operators build on. | **v4.4.0 or higher** |
+| 2 | **Alauda Container Platform Data Services RDS Framework** | Base operator framework that the MySQL operator extends. | **v4.3.x** |
+| 3 | **Alauda Database Service for MySQL** | The MySQL-MGR operator and its instances. | **v4.4.0 or higher** |
+| 4 | **Query Analytics Operator** (`query-analytics-operator`) | Optional companion operator that powers slow query logging and query analysis. Only required if query analytics features are used. | **v4.4.0 or higher** |
+
+:::warning Upgrade the base plugins first
+Always upgrade the **Data Services RDS Framework** to **v4.3.x** **before** upgrading the MySQL operator or rolling instances. Upgrading the MySQL operator against an older RDS Framework can leave instances in an inconsistent or unmanaged state. The OperatorHub **Upgrade** prompt lists the component and plugin version changes for the target release; see the [Install guide](./installation) for the plugin installation steps.
+:::
+
+### Important Notes
+
+- **Data Services Essentials version**: Upgrading the MySQL operator requires **Alauda Container Platform Data Services Essentials (Application Services Core) v4.4.0 or higher**. Upgrade this foundational platform component to a compatible version **before** upgrading the operator.
+- **Upgrade the base plugins first**: The MySQL operator depends on the Alauda Container Platform Data Services RDS Framework. Upgrade the RDS Framework to **v4.3.x** **before** upgrading the operator. See [Plugin Dependencies](#plugin-dependencies).
+- **Query Analytics operator version**: If you use query analytics features (slow query logging and query analysis), upgrade the **Query Analytics Operator (`query-analytics-operator`) to v4.4.0 or higher**. This operator is optional — MySQL-MGR instances function normally without it.
+- **MySQL-PXC removal is irreversible**: Starting from MySQL Operator v4.3.0, MySQL-PXC is removed. PXC instances become **unmanaged** immediately after the operator upgrade and cannot be re-managed. Migrate any PXC instances to MySQL-MGR **before** upgrading to v4.3.0 or later — see the [MySQL-PXC Pre-Upgrade Checklist](#mysql-pxc-pre-upgrade-checklist).
+- **Operator rollback is not supported**: Once upgraded, the MySQL operator **cannot be rolled back** to a previous version. Take a verified full backup of every instance before starting the upgrade. See [Rollback considerations](#rollback-considerations).
+
 ## MySQL Major Version Upgrade (8.0 → 8.4)
 
 Starting from v4.4.0, you can upgrade an existing MySQL **8.0** MGR cluster **in place** to MySQL **8.4** without rebuilding the cluster or migrating data. The operator performs a rolling, member-by-member upgrade that preserves data and Group Replication membership, upgrades the InnoDB Cluster metadata automatically, and keeps the cluster serving traffic through MySQL Router.
@@ -35,7 +68,7 @@ This is a **major-version** upgrade and is **not reversible** — plan a mainten
 
 For prerequisites and the full step-by-step procedure, see [Upgrade MySQL 8.0 to 8.4](./how_to/32-upgrade-8.0-to-8.4).
 
-## MySQL-PXC Pre-Upgrade Checklist
+## MySQL-PXC Pre-Upgrade Checklist \{#mysql-pxc-pre-upgrade-checklist}
 
 If your platform has **MySQL-PXC** instances, complete the following **before upgrading to MySQL Operator v4.3.0 or later**:
 
@@ -190,7 +223,7 @@ If migration cannot be completed within the maintenance window:
 Deleting a PXC custom resource will delete all associated pods and data. Always verify data integrity on the target MGR instance before decommissioning the source PXC instance.
 :::
 
-### Rollback considerations
+### Rollback considerations \{#rollback-considerations}
 
 The MySQL operator **cannot be rolled back** to a previous version after upgrade. If a critical issue occurs:
 

--- a/docs/en/upgrade.mdx
+++ b/docs/en/upgrade.mdx
@@ -43,10 +43,10 @@ Like other Alauda Container Platform Data Services plugins, MySQL-MGR depends on
 
 | Order | Plugin | Role | Minimum Version |
 |-------|--------|------|-----------------|
-| 1 | **Alauda Container Platform Data Services Essentials** (also referred to as Application Services Core) | Foundational platform component that the Data Services plugins and operators build on. | **v4.4.0 or higher** |
-| 2 | **Alauda Container Platform Data Services RDS Framework** (`rds-operator`) | The rds-operator multi-database base operator that the MySQL operator extends. | **v4.3.0 or higher** |
-| 3 | **Alauda Database Service for MySQL** | The MySQL-MGR operator and its instances. | **v4.4.0 or higher** |
-| 4 | **Query Analytics Operator** (`query-analytics-operator`) | Optional companion operator that powers slow query logging and query analysis. Only required if query analytics features are used. | **v4.4.0 or higher** |
+| 1 | **Alauda Container Platform Data Services Essentials** (also referred to as Application Services Core) | Foundational platform component that the Data Services plugins and operators build on. | **v4.4.0** |
+| 2 | **Alauda Container Platform Data Services RDS Framework** (`rds-operator`) | The rds-operator multi-database base operator that the MySQL operator extends. | **v4.3.0** |
+| 3 | **Alauda Database Service for MySQL** | The MySQL-MGR operator and its instances. | **v4.4.0** |
+| 4 | **Query Analytics Operator** (`query-analytics-operator`) | Optional companion operator that powers slow query logging and query analysis. Only required if query analytics features are used. | **v4.4.0** |
 
 :::warning Upgrade the base plugins first
 Always upgrade the **Data Services RDS Framework** (`rds-operator`) to **v4.3.0 or higher** **before** upgrading the MySQL operator or rolling instances. Upgrading the MySQL operator against an older rds-operator can leave instances in an inconsistent or unmanaged state. The OperatorHub **Upgrade** prompt lists the component and plugin version changes for the target release; see the [Install guide](./installation) for the plugin installation steps.

--- a/docs/en/upgrade.mdx
+++ b/docs/en/upgrade.mdx
@@ -44,18 +44,18 @@ Like other Alauda Container Platform Data Services plugins, MySQL-MGR depends on
 | Order | Plugin | Role | Minimum Version |
 |-------|--------|------|-----------------|
 | 1 | **Alauda Container Platform Data Services Essentials** (also referred to as Application Services Core) | Foundational platform component that the Data Services plugins and operators build on. | **v4.4.0 or higher** |
-| 2 | **Alauda Container Platform Data Services RDS Framework** | Base operator framework that the MySQL operator extends. | **v4.3.x** |
+| 2 | **Alauda Container Platform Data Services RDS Framework** (`rds-operator`) | The rds-operator multi-database base operator that the MySQL operator extends. | **v4.3.0 or higher** |
 | 3 | **Alauda Database Service for MySQL** | The MySQL-MGR operator and its instances. | **v4.4.0 or higher** |
 | 4 | **Query Analytics Operator** (`query-analytics-operator`) | Optional companion operator that powers slow query logging and query analysis. Only required if query analytics features are used. | **v4.4.0 or higher** |
 
 :::warning Upgrade the base plugins first
-Always upgrade the **Data Services RDS Framework** to **v4.3.x** **before** upgrading the MySQL operator or rolling instances. Upgrading the MySQL operator against an older RDS Framework can leave instances in an inconsistent or unmanaged state. The OperatorHub **Upgrade** prompt lists the component and plugin version changes for the target release; see the [Install guide](./installation) for the plugin installation steps.
+Always upgrade the **Data Services RDS Framework** (`rds-operator`) to **v4.3.0 or higher** **before** upgrading the MySQL operator or rolling instances. Upgrading the MySQL operator against an older rds-operator can leave instances in an inconsistent or unmanaged state. The OperatorHub **Upgrade** prompt lists the component and plugin version changes for the target release; see the [Install guide](./installation) for the plugin installation steps.
 :::
 
 ### Important Notes
 
 - **Data Services Essentials version**: Upgrading the MySQL operator requires **Alauda Container Platform Data Services Essentials (Application Services Core) v4.4.0 or higher**. Upgrade this foundational platform component to a compatible version **before** upgrading the operator.
-- **Upgrade the base plugins first**: The MySQL operator depends on the Alauda Container Platform Data Services RDS Framework. Upgrade the RDS Framework to **v4.3.x** **before** upgrading the operator. See [Plugin Dependencies](#plugin-dependencies).
+- **Upgrade the base plugins first**: The MySQL operator depends on the Alauda Container Platform Data Services RDS Framework (`rds-operator`). Upgrade the rds-operator to **v4.3.0 or higher** **before** upgrading the operator. See [Plugin Dependencies](#plugin-dependencies).
 - **Query Analytics operator version**: If you use query analytics features (slow query logging and query analysis), upgrade the **Query Analytics Operator (`query-analytics-operator`) to v4.4.0 or higher**. This operator is optional — MySQL-MGR instances function normally without it.
 - **MySQL-PXC removal is irreversible**: Starting from MySQL Operator v4.3.0, MySQL-PXC is removed. PXC instances become **unmanaged** immediately after the operator upgrade and cannot be re-managed. Migrate any PXC instances to MySQL-MGR **before** upgrading to v4.3.0 or later — see the [MySQL-PXC Pre-Upgrade Checklist](#mysql-pxc-pre-upgrade-checklist).
 - **Operator rollback is not supported**: Once upgraded, the MySQL operator **cannot be rolled back** to a previous version. Take a verified full backup of every instance before starting the upgrade. See [Rollback considerations](#rollback-considerations).


### PR DESCRIPTION
## What

Mirror of #52 / #53 onto the **release-4.4** branch (the v4.4.0 docs branch).

Adds the **Prerequisites** section (Plugin Dependencies table + Important Notes) covering the v4.4.0 base-plugin requirements:

| Order | Plugin | Minimum Version |
|---|---|---|
| 1 | Data Services Essentials (a.k.a. Application Services Core) | **v4.4.0+** |
| 2 | Data Services RDS Framework | **v4.3.x** |
| 3 | Alauda Database Service for MySQL | **v4.4.0+** |
| 4 | Query Analytics Operator (`query-analytics-operator`, optional) | **v4.4.0+** |

Important Notes: base plugins first, Query Analytics version (when used), MySQL-PXC removal irreversible, no operator rollback. Page retitled "Upgrade to v4.4.0".

## Integration notes (release-4.4 differs from master)

release-4.4 already had v4.4.0-specific upgrade content that master/release-4.3 did not, so this is **not** a blind mirror:

- The Prerequisites section is inserted **after** the existing "three kinds of upgrade" intro and **before** the existing **MySQL Major Version Upgrade (8.0 → 8.4)** section — both of which are left untouched.
- The separate scoping intro paragraph used in #52/#53 was **omitted** here to avoid duplicating the existing "three kinds of upgrade" list (which already links the patch-version guide).
- Diff is +36/-3 (the deletions are only the retitled H1 and two headings that gained explicit `\{#id}` anchors).

In-page-link targets use explicit `\{#id}` anchors (doom 1.22.x auto-slug does not reliably match). Lint clean on doom 1.12.1 and 1.22.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)