### PR TITLE
docs: add v4.3.4 release notes (MIDDLEWARE-32427)

### DIFF
--- a/docs/en/how_to/40-deploy-without-topolvm.mdx
+++ b/docs/en/how_to/40-deploy-without-topolvm.mdx
@@ -15,7 +15,7 @@ productsVersion:
 
 # Deploy MySQL-MGR Without TopoLVM
 
-This guide provides instructions for deploying MySQL Group Replication (MGR) instances on clusters where TopoLVM is not available, such as clusters running MicroOS (SUSE Linux Enterprise Micro) or other environments that use alternative storage provisioners.
+This guide provides instructions for deploying MySQL Group Replication (MGR) instances on clusters where TopoLVM is not available, such as clusters running Alauda OS (SUSE Linux Enterprise Micro) or other environments that use alternative storage provisioners.
 
 ## Background
 
@@ -23,7 +23,7 @@ This guide provides instructions for deploying MySQL Group Replication (MGR) ins
 
 MySQL-MGR typically relies on TopoLVM for dynamic volume provisioning. However, some environments do not support TopoLVM:
 
-- **MicroOS clusters**: The root filesystem is read-only, and TopoLVM may not be installed.
+- **Alauda OS clusters**: The root filesystem is read-only, and TopoLVM may not be installed.
 - **Bare-metal clusters**: Some clusters use local storage with manual PV provisioning.
 - **Test/evaluation environments**: Lightweight setups that don't include TopoLVM.
 
@@ -58,7 +58,7 @@ If you need query analytics features (slow query logging, query analysis), the f
 | **query-analytics-operator** | Query analytics and slow query logging |
 
 :::warning
-On read-only filesystems (e.g., MicroOS), you **must** configure the ClickHouse storage path in the `RdsInstaller` CR **before** installing the query-analytics-operator. Otherwise, the operator will immediately create a ClickHouse PV at the default `/cpaas/ck` host path, which will fail with `read-only file system`. See [Step 3](#step-3-optional-configure-clickhouse-storage-path-on-read-only-filesystems) for details.
+On read-only filesystems (e.g., Alauda OS), you **must** configure the ClickHouse storage path in the `RdsInstaller` CR **before** installing the query-analytics-operator. Otherwise, the operator will immediately create a ClickHouse PV at the default `/cpaas/ck` host path, which will fail with `read-only file system`. See [Step 3](#step-3-optional-configure-clickhouse-storage-path-on-read-only-filesystems) for details.
 :::
 
 :::info
@@ -77,7 +77,7 @@ All operators should show `Succeeded` in the `PHASE` column.
 
 - At least 3 worker nodes are recommended for production deployments (MySQL-MGR requires 3 members for group replication quorum). Single-member deployments are possible for testing.
 - Sufficient CPU and memory resources on each node.
-- A writable directory path available on all nodes (e.g., `/opt/local-pv/` on MicroOS).
+- A writable directory path available on all nodes (e.g., `/opt/local-pv/` on Alauda OS).
 
 ## Step 1: Create a Local StorageClass
 
@@ -108,7 +108,7 @@ Each MySQL-MGR member requires one PV. For a 3-member cluster, create at least 3
 
 ### Create Directories on Nodes
 
-On MicroOS, the root filesystem is read-only. Use `/opt/local-pv/` as the base path:
+On Alauda OS, the root filesystem is read-only. Use `/opt/local-pv/` as the base path:
 
 ```bash
 # Run on each worker node, or use a privileged pod
@@ -119,7 +119,7 @@ done
 ```
 
 :::warning
-- **Path**: On MicroOS, do not use `/data` or other root-level paths — they will fail with `read-only file system`. Use `/opt/local-pv/` instead.
+- **Path**: On Alauda OS, do not use `/data` or other root-level paths — they will fail with `read-only file system`. Use `/opt/local-pv/` instead.
 - **Permissions**: `chmod 777` is a convenience workaround because MySQL containers run as a non-root user with a UID/GID that may not match the host. Without write permissions, `mysqld --initialize` will fail with `Permission denied`. For production environments, consider setting ownership to the specific UID used by the MySQL container (typically `999:999`) instead of using `777`.
 - **Stale data**: If reusing PV directories, remove all existing files first with `rm -rf /opt/local-pv/pvN/*`. MySQL initialization fails if the data directory is not empty.
 :::
@@ -194,7 +194,7 @@ All PVs should show `Available` status before proceeding.
 This step is only needed if you plan to use query analytics features (slow query logging, query analysis). If you do not use query analytics, skip this step — MySQL-MGR instances will function normally without it.
 :::
 
-The query-analytics plugin deploys ClickHouse using a host directory PV. By default, the host path is `/cpaas/ck`. On MicroOS or other systems with a read-only root filesystem, this causes ClickHouse pods to fail with:
+The query-analytics plugin deploys ClickHouse using a host directory PV. By default, the host path is `/cpaas/ck`. On Alauda OS or other systems with a read-only root filesystem, this causes ClickHouse pods to fail with:
 
 ```
 mkdir /cpaas: read-only file system
@@ -229,7 +229,7 @@ You must configure the `hostPath` **before** installing the query-analytics-oper
     ```
 
     :::info
-    On MicroOS, use a path under `/opt/` (e.g., `/opt/local-pv/ck`). The directory will be created automatically with `DirectoryOrCreate` type.
+    On Alauda OS, use a path under `/opt/` (e.g., `/opt/local-pv/ck`). The directory will be created automatically with `DirectoryOrCreate` type.
     :::
 
 4. Now install the **clickhouse-operator** and **query-analytics-operator**. The ClickHouse PV will be created using the configured path instead of the default `/cpaas/ck`.

--- a/docs/en/release_notes.mdx
+++ b/docs/en/release_notes.mdx
@@ -6,6 +6,16 @@ i18n:
     zh: 发版说明
 title: Release Notes
 ---
+## v4.3.4
+
+### Fixed Issues
+
+{/* release-notes-for-bugs?template=mw-mgr-v4.3.4-fixed&project=Middleware */}
+
+### Known Issues
+
+{/* release-notes-for-bugs?template=mw-mgr-v4.3-known&project=Middleware */}
+
 ## v4.3.2
 
 ### New and Optimized Features

--- a/docs/en/release_notes.mdx
+++ b/docs/en/release_notes.mdx
@@ -26,7 +26,7 @@ The deprecated MySQL-PXC architecture has been removed. MySQL-MGR is now the sol
 
 #### Deployment on Non-TopoLVM Environments
 
-You can now deploy MySQL-MGR clusters on environments that do not provide TopoLVM, such as MicroOS or bare-metal clusters, by using a manually provisioned local StorageClass. See [Deploy MySQL-MGR Without TopoLVM](./how_to/40-deploy-without-topolvm).
+You can now deploy MySQL-MGR clusters on environments that do not provide TopoLVM, such as Alauda OS or bare-metal clusters, by using a manually provisioned local StorageClass. See [Deploy MySQL-MGR Without TopoLVM](./how_to/40-deploy-without-topolvm).
 
 #### Backup Reliability
 

--- a/doom.config.yml
+++ b/doom.config.yml
@@ -15,5 +15,7 @@ releaseNotes:
   queryTemplates:
     mw-mgr-v4.3.2-fixed: |
       filter = 16502 AND status in (Done, Resolved) AND (labels not in (安全问题) OR labels is EMPTY) AND project = MIDDLEWARE AND Feature = "MiddleWare - MySQL-MGR" AND fixVersion in versionMatch("MGR-v4.3.*") AND ReleaseNotesStatus = Publish
+    mw-mgr-v4.3.4-fixed: |
+      filter = 16502 AND status in (Done, Resolved) AND (labels not in (安全问题) OR labels is EMPTY) AND project = MIDDLEWARE AND Feature = "MiddleWare - MySQL-MGR" AND fixVersion in versionMatch("MGR-v4.3.4") AND ReleaseNotesStatus = Publish
     mw-mgr-v4.3-known: |
       filter = 18959 AND project = MIDDLEWARE AND Feature = "MiddleWare - MySQL-MGR" AND (affectedVersion in versionMatch("MGR-v4.3.*") OR ACPAffectVersions in versionMatch("v4.3.*")) AND status not in (Closed, Done, Resolved, 已验证) AND (labels not in (非产品问题, 非当前版本功能, 安全问题) OR labels is EMPTY) AND ReleaseNotesStatus = Publish


### PR DESCRIPTION
Adds the `## v4.3.4` release-notes section for the 4.3-line maintenance patch.

- Ships the MIDDLEWARE-32415 fix: full logical backup (mysqlsh) could fail on instances containing partitioned tables.
- Fixed Issues uses the standard JIRA template (`mw-mgr-v4.3.4-fixed`) → resolves from fixVersion MGR-v4.3.4 (already set on 32415).
- No CRD/API delta (backup-logic fix); lifecycle policy tracks minor lines, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)